### PR TITLE
[Paperclip] feat: add esm-patient-procedures-app to patient-chart monorepo

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "node": true,
   },

--- a/__mocks__/index.ts
+++ b/__mocks__/index.ts
@@ -24,3 +24,4 @@ export * from './visitQueueEntry.mock';
 export * from './visits.mock';
 export * from './vitals-and-biometrics.mock';
 export * from './mockOrders.mock';
+export * from './procedures.mock';

--- a/__mocks__/procedures.mock.ts
+++ b/__mocks__/procedures.mock.ts
@@ -1,0 +1,88 @@
+const patientUuid = '8673ee4f-e2ab-4077-ba55-4980f408773e';
+
+export const searchedProcedure = [{ uuid: 'proc-concept-uuid-1', display: 'Appendectomy' }];
+
+export const mockProcedureTypes = [
+  { uuid: 'pt-uuid-1', name: 'Surgery' },
+  { uuid: 'pt-uuid-2', name: 'Endoscopy' },
+];
+
+const makeProcedure = (overrides: object) => ({
+  procedureNonCoded: '',
+  estimatedStartDate: null,
+  endDateTime: null,
+  duration: null,
+  durationUnit: null,
+  outcomeCoded: null,
+  outcomeNonCoded: null,
+  notes: '',
+  formNamespaceAndPath: '',
+  voided: false,
+  patient: { uuid: patientUuid, display: 'Test Patient' },
+  ...overrides,
+});
+
+export const mockProceduresResponse = {
+  results: [
+    makeProcedure({
+      uuid: 'proc-uuid-1',
+      display: 'Appendectomy',
+      procedureType: { uuid: 'pt-uuid-1', name: 'Surgery' },
+      procedureCoded: { uuid: 'proc-concept-uuid-1', display: 'Appendectomy' },
+      bodySite: { uuid: 'body-site-uuid-1', display: 'Abdomen' },
+      startDateTime: '2021-08-01T00:00:00.000+0000',
+      endDateTime: '2021-08-01T02:00:00.000+0000',
+      duration: 45,
+      durationUnit: { uuid: 'duration-unit-uuid-1', display: 'Minutes' },
+      status: { uuid: 'status-uuid-1', display: 'Completed' },
+      notes: 'Procedure went well',
+    }),
+    makeProcedure({
+      uuid: 'proc-uuid-2',
+      display: 'Colonoscopy',
+      procedureType: { uuid: 'pt-uuid-2', name: 'Endoscopy' },
+      procedureCoded: { uuid: 'proc-concept-uuid-2', display: 'Colonoscopy' },
+      bodySite: { uuid: 'body-site-uuid-2', display: 'Colon' },
+      startDateTime: '2021-09-01T00:00:00.000+0000',
+      endDateTime: '2021-09-01T01:00:00.000+0000',
+      status: { uuid: 'status-uuid-1', display: 'Completed' },
+    }),
+    makeProcedure({
+      uuid: 'proc-uuid-3',
+      display: 'Blood draw',
+      procedureType: { uuid: 'pt-uuid-1', name: 'Surgery' },
+      procedureCoded: { uuid: 'proc-concept-uuid-3', display: 'Blood draw' },
+      bodySite: { uuid: 'body-site-uuid-3', display: 'Arm' },
+      startDateTime: '2021-10-01T00:00:00.000+0000',
+      status: { uuid: 'status-uuid-2', display: 'In progress' },
+    }),
+    makeProcedure({
+      uuid: 'proc-uuid-4',
+      display: 'Chest x-ray',
+      procedureType: { uuid: 'pt-uuid-2', name: 'Endoscopy' },
+      procedureCoded: { uuid: 'proc-concept-uuid-4', display: 'Chest x-ray' },
+      bodySite: { uuid: 'body-site-uuid-4', display: 'Chest' },
+      startDateTime: '2021-11-01T00:00:00.000+0000',
+      status: { uuid: 'status-uuid-1', display: 'Completed' },
+    }),
+    makeProcedure({
+      uuid: 'proc-uuid-5',
+      display: 'ECG',
+      procedureType: { uuid: 'pt-uuid-1', name: 'Surgery' },
+      procedureCoded: { uuid: 'proc-concept-uuid-5', display: 'ECG' },
+      bodySite: { uuid: 'body-site-uuid-5', display: 'Heart' },
+      startDateTime: '2021-12-01T00:00:00.000+0000',
+      status: { uuid: 'status-uuid-1', display: 'Completed' },
+    }),
+    makeProcedure({
+      uuid: 'proc-uuid-6',
+      display: 'MRI brain',
+      procedureType: { uuid: 'pt-uuid-2', name: 'Endoscopy' },
+      procedureCoded: { uuid: 'proc-concept-uuid-6', display: 'MRI brain' },
+      bodySite: { uuid: 'body-site-uuid-6', display: 'Brain' },
+      startDateTime: '2022-01-01T00:00:00.000+0000',
+      status: { uuid: 'status-uuid-1', display: 'Completed' },
+    }),
+  ],
+  links: [],
+};

--- a/packages/esm-patient-procedures-app/README.md
+++ b/packages/esm-patient-procedures-app/README.md
@@ -1,0 +1,3 @@
+# esm-patient-procedures-app
+
+The procedures widget. It provides a tabular overview of the procedures recorded for a patient as well as a form for recording new procedures.

--- a/packages/esm-patient-procedures-app/jest.config.js
+++ b/packages/esm-patient-procedures-app/jest.config.js
@@ -1,0 +1,3 @@
+const rootConfig = require('../../jest.config.js');
+
+module.exports = rootConfig;

--- a/packages/esm-patient-procedures-app/package.json
+++ b/packages/esm-patient-procedures-app/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@openmrs/esm-patient-procedures-app",
+  "version": "12.1.0",
+  "license": "MPL-2.0",
+  "description": "Patient procedures microfrontend for the OpenMRS SPA",
+  "browser": "dist/openmrs-esm-patient-procedures-app.js",
+  "main": "src/index.ts",
+  "source": true,
+  "scripts": {
+    "start": "openmrs develop",
+    "serve": "rspack serve --mode=development",
+    "debug": "npm run serve",
+    "build": "rspack --mode=production",
+    "analyze": "rspack --mode=production --env analyze=true",
+    "lint": "cross-env eslint src --ext tsx,ts --fix --max-warnings=0",
+    "test": "cross-env TZ=UTC jest --config jest.config.js --verbose false --passWithNoTests --color",
+    "test:watch": "cross-env TZ=UTC jest --watch --config jest.config.js --color",
+    "coverage": "yarn test --coverage",
+    "typescript": "tsc",
+    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.modal.tsx' 'src/**/*.extension.tsx' 'src/**/*.workspace.tsx' 'src/**/*.hook.tsx' 'src/index.ts' --config ../../tools/i18next-parser.config.js"
+  },
+  "browserslist": [
+    "extends browserslist-config-openmrs"
+  ],
+  "keywords": [
+    "openmrs"
+  ],
+  "homepage": "https://github.com/openmrs/openmrs-esm-patient-chart#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openmrs/openmrs-esm-patient-chart.git"
+  },
+  "bugs": {
+    "url": "https://github.com/openmrs/openmrs-esm-patient-chart/issues"
+  },
+  "dependencies": {
+    "@carbon/react": "^1.83.0",
+    "@hookform/resolvers": "^3.3.1",
+    "@openmrs/esm-patient-common-lib": "next",
+    "react-hook-form": "^7.46.2",
+    "zod": "^3.23.8"
+  },
+  "peerDependencies": {
+    "@openmrs/esm-framework": "9.x",
+    "@openmrs/esm-patient-common-lib": "12.x",
+    "dayjs": "1.x",
+    "react": "18.x",
+    "react-i18next": "16.x",
+    "react-router-dom": "6.x",
+    "rxjs": "6.x",
+    "swr": "2.x"
+  },
+  "devDependencies": {
+    "@openmrs/esm-patient-common-lib": "workspace:*",
+    "openmrs": "next"
+  }
+}

--- a/packages/esm-patient-procedures-app/rspack.config.js
+++ b/packages/esm-patient-procedures-app/rspack.config.js
@@ -1,0 +1,1 @@
+module.exports = require('openmrs/default-rspack-config');

--- a/packages/esm-patient-procedures-app/src/config-schema.ts
+++ b/packages/esm-patient-procedures-app/src/config-schema.ts
@@ -1,0 +1,49 @@
+import { Type } from '@openmrs/esm-framework';
+
+export const configSchema = {
+  procedurePageSize: {
+    _type: Type.Number,
+    _description: 'Default page size for the procedures table',
+    _default: 5,
+  },
+  procedureCodedConceptClassUuid: {
+    _type: Type.UUID,
+    _description: 'Concept class UUID for procedure coded concepts',
+    _default: '8d490bf4-c2cc-11de-8d13-0010c6dffd0f',
+  },
+  bodySiteConceptClassUuid: {
+    _type: Type.UUID,
+    _description: 'Concept class UUID for body site concepts',
+    _default: '',
+  },
+  statusConceptClassUuid: {
+    _type: Type.UUID,
+    _description: 'Concept class UUID for procedure status concepts',
+    _default: '',
+  },
+  durationUnitMinutesConceptUuid: {
+    _type: Type.UUID,
+    _description: 'Concept UUID representing the "minutes" duration unit',
+    _default: '1733AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+  durationUnitHoursConceptUuid: {
+    _type: Type.UUID,
+    _description: 'Concept UUID representing the "hours" duration unit',
+    _default: '1822AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+  durationUnitDaysConceptUuid: {
+    _type: Type.UUID,
+    _description: 'Concept UUID representing the "days" duration unit',
+    _default: '1072AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+};
+
+export interface ConfigObject {
+  procedurePageSize: number;
+  procedureCodedConceptClassUuid: string;
+  bodySiteConceptClassUuid: string;
+  statusConceptClassUuid: string;
+  durationUnitMinutesConceptUuid: string;
+  durationUnitHoursConceptUuid: string;
+  durationUnitDaysConceptUuid: string;
+}

--- a/packages/esm-patient-procedures-app/src/constants.ts
+++ b/packages/esm-patient-procedures-app/src/constants.ts
@@ -1,0 +1,1 @@
+export const moduleName = '@openmrs/esm-patient-procedures-app';

--- a/packages/esm-patient-procedures-app/src/dashboard.meta.ts
+++ b/packages/esm-patient-procedures-app/src/dashboard.meta.ts
@@ -1,0 +1,8 @@
+import { type DashboardLinkConfig } from '@openmrs/esm-patient-common-lib';
+
+export const dashboardMeta: DashboardLinkConfig & { slot: string } = {
+  slot: 'patient-chart-procedures-dashboard-slot',
+  path: 'Procedures',
+  title: 'Procedures',
+  icon: 'omrs-icon-procedure-order',
+};

--- a/packages/esm-patient-procedures-app/src/declarations.d.ts
+++ b/packages/esm-patient-procedures-app/src/declarations.d.ts
@@ -1,0 +1,9 @@
+declare module '*.scss' {
+  const content: { [className: string]: string };
+  export default content;
+}
+
+declare module '*.css' {
+  const content: { [className: string]: string };
+  export default content;
+}

--- a/packages/esm-patient-procedures-app/src/index.ts
+++ b/packages/esm-patient-procedures-app/src/index.ts
@@ -1,0 +1,35 @@
+import { getAsyncLifecycle, getSyncLifecycle, defineConfigSchema } from '@openmrs/esm-framework';
+import { createDashboardLink } from '@openmrs/esm-patient-common-lib';
+import { configSchema } from './config-schema';
+import { dashboardMeta } from './dashboard.meta';
+import proceduresOverviewComponent from './procedures/procedures-overview.component';
+import proceduresDetailedSummaryComponent from './procedures/procedures-detailed-summary.component';
+import proceduresFormWorkspaceComponent from './procedures/procedures-form.workspace';
+import { moduleName } from './constants';
+
+const options = {
+  featureName: 'patient-procedures-app',
+  moduleName,
+};
+
+export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
+
+export function startupApp() {
+  defineConfigSchema(moduleName, configSchema);
+}
+
+// Extensions
+export const proceduresOverview = getSyncLifecycle(proceduresOverviewComponent, options);
+
+export const proceduresDetailedSummary = getSyncLifecycle(proceduresDetailedSummaryComponent, options);
+
+export const proceduresDashboardLink =
+  // t('Procedures', 'Procedures')
+  getSyncLifecycle(createDashboardLink({ ...dashboardMeta }), options);
+
+export const proceduresFormWorkspace = getSyncLifecycle(proceduresFormWorkspaceComponent, options);
+
+export const procedureDeleteConfirmationDialog = getAsyncLifecycle(
+  () => import('./procedures/delete-procedure.modal'),
+  options,
+);

--- a/packages/esm-patient-procedures-app/src/patient-procedures-app.component.tsx
+++ b/packages/esm-patient-procedures-app/src/patient-procedures-app.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Layer, Tile } from '@carbon/react';
+import styles from './patient-procedures-app.scss';
+
+const PatientProceduresApp: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.container}>
+      <Layer>
+        <Tile className={styles.tile}>
+          <h1 className={styles.heading}>
+            {t('patient-procedures-appHeading', 'PatientProceduresApp')}
+          </h1>
+          <p className={styles.content}>
+            {t('patient-procedures-appDescription', 'Welcome to the PatientProceduresApp page.')}
+          </p>
+        </Tile>
+      </Layer>
+    </div>
+  );
+};
+
+export default PatientProceduresApp;

--- a/packages/esm-patient-procedures-app/src/patient-procedures-app.scss
+++ b/packages/esm-patient-procedures-app/src/patient-procedures-app.scss
@@ -1,0 +1,25 @@
+@use '@carbon/layout';
+@use '@carbon/type';
+
+.container {
+  padding: layout.$spacing-05;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.tile {
+  padding: layout.$spacing-06;
+  margin-bottom: layout.$spacing-05;
+}
+
+.heading {
+  @include type.type-style('heading-03');
+  margin-bottom: layout.$spacing-04;
+  color: var(--cds-text-primary);
+}
+
+.content {
+  @include type.type-style('body-01');
+  color: var(--cds-text-secondary);
+  line-height: 1.5;
+}

--- a/packages/esm-patient-procedures-app/src/procedures-app.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures-app.component.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Layer, Tile } from '@carbon/react';
+import styles from './procedures-app.scss';
+
+const ProceduresApp: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.container}>
+      <Layer>
+        <Tile className={styles.tile}>
+          <h1 className={styles.heading}>
+            {t('procedures-appHeading', 'ProceduresApp')}
+          </h1>
+          <p className={styles.content}>
+            {t('procedures-appDescription', 'Welcome to the ProceduresApp page.')}
+          </p>
+        </Tile>
+      </Layer>
+    </div>
+  );
+};
+
+export default ProceduresApp;

--- a/packages/esm-patient-procedures-app/src/procedures-app.scss
+++ b/packages/esm-patient-procedures-app/src/procedures-app.scss
@@ -1,0 +1,25 @@
+@use '@carbon/layout';
+@use '@carbon/type';
+
+.container {
+  padding: layout.$spacing-05;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.tile {
+  padding: layout.$spacing-06;
+  margin-bottom: layout.$spacing-05;
+}
+
+.heading {
+  @include type.type-style('heading-03');
+  margin-bottom: layout.$spacing-04;
+  color: var(--cds-text-primary);
+}
+
+.content {
+  @include type.type-style('body-01');
+  color: var(--cds-text-secondary);
+  line-height: 1.5;
+}

--- a/packages/esm-patient-procedures-app/src/procedures/date-time-field.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/date-time-field.component.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm, useWatch } from 'react-hook-form';
+import { DateTimeField } from './date-time-field.component';
+import { type ProceduresFormSchema } from './procedures-form.workspace';
+
+interface HarnessProps {
+  defaultValue?: Date | null;
+  fieldName?: 'startDateTime' | 'endDateTime';
+  idPrefix?: string;
+}
+
+function Harness({ defaultValue = null, fieldName = 'startDateTime', idPrefix = 'start' }: HarnessProps) {
+  const { control } = useForm<ProceduresFormSchema>({
+    defaultValues: { [fieldName]: defaultValue } as Partial<ProceduresFormSchema>,
+  });
+  const value = useWatch({ control, name: fieldName });
+  return (
+    <div>
+      <DateTimeField name={fieldName} idPrefix={idPrefix} control={control} />
+      <output data-testid="iso">{value ? (value as Date).toISOString() : ''}</output>
+      <output data-testid="hours">{value ? String((value as Date).getHours()) : ''}</output>
+      <output data-testid="minutes">{value ? String((value as Date).getMinutes()) : ''}</output>
+    </div>
+  );
+}
+
+async function pickDate(user: ReturnType<typeof userEvent.setup>, date = '2026-04-27') {
+  const dateInput = screen.getByLabelText(/^date$/i);
+  await user.click(dateInput);
+  await user.paste(date);
+}
+
+describe('DateTimeField', () => {
+  it('renders date, time, and AM/PM controls', () => {
+    render(<Harness />);
+
+    expect(screen.getByLabelText(/^date$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^time$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/am\/pm/i)).toBeInTheDocument();
+  });
+
+  it('disables the time and meridiem inputs until a date is picked', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    expect(screen.getByLabelText(/^time$/i)).toBeDisabled();
+    expect(screen.getByLabelText(/am\/pm/i)).toBeDisabled();
+
+    await pickDate(user);
+
+    expect(screen.getByLabelText(/^time$/i)).toBeEnabled();
+    expect(screen.getByLabelText(/am\/pm/i)).toBeEnabled();
+  });
+
+  it('combines a 12-hour time with the AM meridiem into a morning datetime', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user);
+    await user.type(screen.getByLabelText(/^time$/i), '09:15');
+
+    expect(screen.getByTestId('hours')).toHaveTextContent('9');
+    expect(screen.getByTestId('minutes')).toHaveTextContent('15');
+  });
+
+  it('flips the underlying hour by 12 when the meridiem changes from AM to PM', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user);
+    await user.type(screen.getByLabelText(/^time$/i), '02:30');
+    expect(screen.getByTestId('hours')).toHaveTextContent('2');
+
+    await user.selectOptions(screen.getByLabelText(/am\/pm/i), 'PM');
+
+    expect(screen.getByTestId('hours')).toHaveTextContent('14');
+    expect(screen.getByTestId('minutes')).toHaveTextContent('30');
+  });
+
+  it('treats 12:00 AM as midnight and 12:00 PM as noon', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user);
+    await user.type(screen.getByLabelText(/^time$/i), '12:00');
+    expect(screen.getByTestId('hours')).toHaveTextContent('0');
+
+    await user.selectOptions(screen.getByLabelText(/am\/pm/i), 'PM');
+    expect(screen.getByTestId('hours')).toHaveTextContent('12');
+  });
+
+  it('ignores time input that does not match the 12-hour pattern', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user);
+    const timeInput = screen.getByLabelText(/^time$/i);
+    await user.type(timeInput, '09:15');
+    await user.clear(timeInput);
+    await user.type(timeInput, '25:99');
+
+    expect(screen.getByTestId('hours')).toHaveTextContent('9');
+    expect(screen.getByTestId('minutes')).toHaveTextContent('15');
+  });
+
+  it('reflects the meridiem of the initial value (PM)', () => {
+    render(<Harness defaultValue={new Date(2026, 3, 27, 14, 30)} />);
+
+    expect(screen.getByLabelText(/am\/pm/i)).toHaveValue('PM');
+    expect(screen.getByLabelText(/^time$/i)).toHaveValue('02:30');
+  });
+
+  it('reflects the meridiem of the initial value (AM at midnight)', () => {
+    render(<Harness defaultValue={new Date(2026, 3, 27, 0, 0)} />);
+
+    expect(screen.getByLabelText(/am\/pm/i)).toHaveValue('AM');
+    expect(screen.getByLabelText(/^time$/i)).toHaveValue('12:00');
+  });
+
+  it('uses the idPrefix prop for the rendered control ids', () => {
+    render(<Harness fieldName="endDateTime" idPrefix="end" />);
+
+    expect(screen.getByLabelText(/^date$/i)).toHaveAttribute('id', 'end-date');
+    expect(screen.getByLabelText(/^time$/i)).toHaveAttribute('id', 'end-time');
+    expect(screen.getByLabelText(/am\/pm/i)).toHaveAttribute('id', 'end-meridiem');
+  });
+
+  it('keeps the date when only the time changes', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user, '2026-04-27');
+    await user.type(screen.getByLabelText(/^time$/i), '09:15');
+
+    expect(screen.getByTestId('iso')).toHaveTextContent(/^2026-04-27T/);
+  });
+
+  it('does not change the value when re-selecting the same meridiem', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await pickDate(user);
+    await user.type(screen.getByLabelText(/^time$/i), '09:15');
+    const before = screen.getByTestId('iso').textContent ?? '';
+
+    await user.selectOptions(screen.getByLabelText(/am\/pm/i), 'AM');
+
+    expect(screen.getByTestId('iso')).toHaveTextContent(before);
+  });
+
+  it('initialises with no value when defaultValue is null', () => {
+    render(<Harness defaultValue={null} />);
+
+    expect(screen.getByTestId('iso')).toBeEmptyDOMElement();
+    expect(screen.getByLabelText(/am\/pm/i)).toHaveValue('AM');
+  });
+});

--- a/packages/esm-patient-procedures-app/src/procedures/date-time-field.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/date-time-field.component.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SelectItem, TimePicker, TimePickerSelect } from '@carbon/react';
+import { Controller, type Control } from 'react-hook-form';
+import { OpenmrsDatePicker, ResponsiveWrapper } from '@openmrs/esm-framework';
+import { type ProceduresFormSchema } from './procedures-form.workspace';
+import styles from './procedures-form.scss';
+
+const TIME_PATTERN = /^(1[0-2]|0?[1-9]):([0-5]\d)$/;
+
+function formatTime(date: Date | null | undefined): string {
+  if (!date) return '';
+  const hours24 = date.getHours();
+  const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  return `${String(hours12).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function getMeridiem(date: Date | null | undefined): 'AM' | 'PM' {
+  if (!date) return 'AM';
+  return date.getHours() >= 12 ? 'PM' : 'AM';
+}
+
+function to24Hour(hours12: number, meridiem: 'AM' | 'PM'): number {
+  if (meridiem === 'AM') return hours12 === 12 ? 0 : hours12;
+  return hours12 === 12 ? 12 : hours12 + 12;
+}
+
+interface DateTimeFieldProps {
+  name: 'startDateTime' | 'endDateTime';
+  idPrefix: string;
+  control: Control<ProceduresFormSchema>;
+}
+
+export function DateTimeField({ name, idPrefix, control }: DateTimeFieldProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field, fieldState }) => {
+        const dateValue = field.value ?? null;
+        const errorText = fieldState?.error?.message;
+        const invalid = Boolean(errorText);
+        const meridiem = getMeridiem(dateValue);
+
+        const handleDateChange = (next: Date | null | undefined) => {
+          if (!next) {
+            field.onChange(null);
+            return;
+          }
+          const merged = new Date(next);
+          if (dateValue) {
+            merged.setHours(dateValue.getHours(), dateValue.getMinutes(), 0, 0);
+          } else {
+            merged.setHours(0, 0, 0, 0);
+          }
+          field.onChange(merged);
+        };
+
+        const handleTimeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+          const raw = event.target.value;
+          const match = TIME_PATTERN.exec(raw);
+          if (!match) return;
+          const base = dateValue ?? new Date();
+          const merged = new Date(base);
+          const hours12 = Number(match[1]);
+          merged.setHours(to24Hour(hours12, meridiem), Number(match[2]), 0, 0);
+          field.onChange(merged);
+        };
+
+        const handleMeridiemChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+          if (!dateValue) return;
+          const next = event.target.value as 'AM' | 'PM';
+          if (next === meridiem) return;
+          const merged = new Date(dateValue);
+          merged.setHours((dateValue.getHours() + 12) % 24, dateValue.getMinutes(), 0, 0);
+          field.onChange(merged);
+        };
+
+        return (
+          <div className={styles.dateTimeFieldGroup}>
+            <ResponsiveWrapper>
+              <OpenmrsDatePicker
+                value={dateValue}
+                onChange={handleDateChange}
+                id={`${idPrefix}-date`}
+                labelText={t('date', 'Date')}
+                invalid={invalid}
+                invalidText={errorText}
+              />
+            </ResponsiveWrapper>
+            <TimePicker
+              id={`${idPrefix}-time`}
+              labelText={t('time', 'Time')}
+              placeholder="hh:mm"
+              pattern="(1[0-2]|0?[1-9]):[0-5][0-9]"
+              maxLength={5}
+              defaultValue={formatTime(dateValue)}
+              onChange={handleTimeChange}
+              disabled={!dateValue}
+            >
+              <TimePickerSelect
+                id={`${idPrefix}-meridiem`}
+                aria-label={t('amPm', 'AM/PM')}
+                value={meridiem}
+                onChange={handleMeridiemChange}
+                disabled={!dateValue}
+              >
+                <SelectItem value="AM" text={t('am', 'AM')} />
+                <SelectItem value="PM" text={t('pm', 'PM')} />
+              </TimePickerSelect>
+            </TimePicker>
+          </div>
+        );
+      }}
+    />
+  );
+}

--- a/packages/esm-patient-procedures-app/src/procedures/delete-procedure.modal.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/delete-procedure.modal.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { mockPatient } from 'tools';
+import { showSnackbar, type FetchResponse } from '@openmrs/esm-framework';
+import DeleteProcedureModal from './delete-procedure.modal';
+import { deleteProcedure } from './procedures.resource';
+
+const mockDeleteProcedure = jest.mocked(deleteProcedure);
+const mockShowSnackbar = jest.mocked(showSnackbar);
+
+jest.mock('./procedures.resource', () => ({
+  ...jest.requireActual('./procedures.resource'),
+  deleteProcedure: jest.fn(),
+  useMutatePatientProcedures: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+const defaultProps = {
+  closeDeleteModal: jest.fn(),
+  procedureUuid: '123e4567-e89b-12d3-a456-426614174000',
+  patientUuid: mockPatient.id,
+};
+
+describe('<DeleteProcedureModal />', () => {
+  it('renders a modal with the correct elements', () => {
+    render(<DeleteProcedureModal {...defaultProps} />);
+
+    expect(screen.getByRole('heading', { name: /delete procedure/i })).toBeInTheDocument();
+    expect(screen.getByText(/are you sure you want to delete this procedure/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it('clicking the Cancel button closes the modal', async () => {
+    const user = userEvent.setup();
+
+    render(<DeleteProcedureModal {...defaultProps} />);
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await user.click(cancelButton);
+    expect(defaultProps.closeDeleteModal).toHaveBeenCalled();
+  });
+
+  it('clicking the Delete button deletes the procedure', async () => {
+    const user = userEvent.setup();
+    mockDeleteProcedure.mockResolvedValue({ status: 200, data: {} } as unknown as FetchResponse);
+
+    render(<DeleteProcedureModal {...defaultProps} />);
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    expect(mockDeleteProcedure).toHaveBeenCalledTimes(1);
+    expect(mockDeleteProcedure).toHaveBeenCalledWith(defaultProps.procedureUuid);
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      isLowContrast: true,
+      kind: 'success',
+      title: 'Procedure deleted',
+    });
+  });
+
+  it('renders an error message if the delete operation fails', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    mockDeleteProcedure.mockRejectedValue({ message: 'Internal server error', status: 500 });
+
+    render(<DeleteProcedureModal {...defaultProps} />);
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    expect(mockDeleteProcedure).toHaveBeenCalledTimes(1);
+    expect(mockDeleteProcedure).toHaveBeenCalledWith(defaultProps.procedureUuid);
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
+    expect(mockShowSnackbar).toHaveBeenCalledWith({
+      isLowContrast: false,
+      kind: 'error',
+      title: 'Error deleting procedure',
+      subtitle: 'Internal server error',
+    });
+    expect(deleteButton).toBeDisabled();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/esm-patient-procedures-app/src/procedures/delete-procedure.modal.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/delete-procedure.modal.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, InlineLoading, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import { showSnackbar } from '@openmrs/esm-framework';
+import styles from './delete-procedure.scss';
+import { deleteProcedure, useMutatePatientProcedures } from './procedures.resource';
+
+interface DeleteProcedureModalProps {
+  closeDeleteModal: () => void;
+  procedureUuid: string;
+  patientUuid: string;
+}
+
+const DeleteProcedureModal: React.FC<DeleteProcedureModalProps> = ({
+  closeDeleteModal,
+  procedureUuid,
+  patientUuid,
+}) => {
+  const { t } = useTranslation();
+  const mutate = useMutatePatientProcedures(patientUuid);
+
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+
+    try {
+      await deleteProcedure(procedureUuid);
+      await mutate();
+
+      closeDeleteModal();
+      showSnackbar({
+        isLowContrast: true,
+        kind: 'success',
+        title: t('procedureDeleted', 'Procedure deleted'),
+      });
+    } catch (error) {
+      console.error('Error deleting procedure: ', error);
+
+      showSnackbar({
+        isLowContrast: false,
+        kind: 'error',
+        title: t('errorDeletingProcedure', 'Error deleting procedure'),
+        subtitle: error?.message,
+      });
+    }
+  }, [closeDeleteModal, procedureUuid, mutate, t]);
+
+  return (
+    <div>
+      <ModalHeader closeModal={closeDeleteModal} title={t('deleteProcedure', 'Delete procedure')} />
+      <ModalBody>
+        <p>{t('deleteModalConfirmationText', 'Are you sure you want to delete this procedure?')}</p>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={closeDeleteModal}>
+          {t('cancel', 'Cancel')}
+        </Button>
+        <Button className={styles.deleteButton} kind="danger" onClick={handleDelete} disabled={isDeleting}>
+          {isDeleting ? (
+            <InlineLoading description={t('deleting', 'Deleting') + '...'} />
+          ) : (
+            <span>{t('delete', 'Delete')}</span>
+          )}
+        </Button>
+      </ModalFooter>
+    </div>
+  );
+};
+
+export default DeleteProcedureModal;

--- a/packages/esm-patient-procedures-app/src/procedures/delete-procedure.scss
+++ b/packages/esm-patient-procedures-app/src/procedures/delete-procedure.scss
@@ -1,0 +1,7 @@
+@use '@carbon/layout';
+
+.deleteButton {
+  :global(.cds--inline-loading) {
+    min-height: layout.$spacing-05;
+  }
+}

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-action-menu.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-action-menu.component.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Layer, OverflowMenu, OverflowMenuItem } from '@carbon/react';
+import { launchWorkspace2, showModal, useLayoutType } from '@openmrs/esm-framework';
+import styles from './procedures-action-menu.scss';
+import { type Procedure } from '../types';
+
+interface ProceduresActionMenuProps {
+  procedure: Procedure;
+  patientUuid: string;
+}
+
+export const ProceduresActionMenu = ({ procedure, patientUuid }: ProceduresActionMenuProps) => {
+  const { t } = useTranslation();
+  const isTablet = useLayoutType() === 'tablet';
+
+  const launchEditConditionsForm = useCallback(
+    () =>
+      launchWorkspace2('procedures-form-workspace', {
+        procedure,
+        formContext: 'editing',
+      }),
+    [procedure],
+  );
+
+  const launchDeleteConditionDialog = (procedureUuid: string) => {
+    const dispose = showModal('procedure-delete-confirmation-dialog', {
+      closeDeleteModal: () => dispose(),
+      procedureUuid,
+      patientUuid,
+    });
+  };
+
+  return (
+    <Layer className={styles.layer}>
+      <OverflowMenu aria-label="Edit or delete condition" align="left" size={isTablet ? 'lg' : 'sm'} flipped>
+        <OverflowMenuItem
+          className={styles.menuItem}
+          id="editCondition"
+          onClick={launchEditConditionsForm}
+          itemText={t('edit', 'Edit')}
+        />
+        <OverflowMenuItem
+          className={styles.menuItem}
+          id="deleteCondition"
+          itemText={t('delete', 'Delete')}
+          onClick={() => launchDeleteConditionDialog(procedure.uuid)}
+          isDelete
+          hasDivider
+        />
+      </OverflowMenu>
+    </Layer>
+  );
+};

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-action-menu.scss
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-action-menu.scss
@@ -1,0 +1,11 @@
+.layer {
+  height: 100%;
+
+  :global(.cds--overflow-menu) {
+    min-height: unset;
+  }
+}
+
+.menuItem {
+  max-width: none;
+}

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.test.tsx
@@ -7,7 +7,7 @@ import ProceduresDetailedSummary from './procedures-detailed-summary.component';
 import { mockProceduresResponse } from '__mocks__';
 
 jest.mock('./procedures-action-menu.component', () => ({
-  ProceduresActionMenu: () => <div data-testid="procedures-action-menu" />,
+  ProceduresActionMenu: jest.fn().mockReturnValue(null),
 }));
 
 const mockOpenmrsFetch = jest.mocked(openmrsFetch);

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type FetchResponse, launchWorkspace2, openmrsFetch } from '@openmrs/esm-framework';
+import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
+import ProceduresDetailedSummary from './procedures-detailed-summary.component';
+import { mockProceduresResponse } from '__mocks__';
+
+jest.mock('./procedures-action-menu.component', () => ({
+  ProceduresActionMenu: () => <div data-testid="procedures-action-menu" />,
+}));
+
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
+const mockLaunchWorkspace2 = jest.mocked(launchWorkspace2);
+
+describe('ProceduresDetailedSummary', () => {
+  it('renders an empty state view if procedures data is unavailable', async () => {
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { results: [] } } as FetchResponse);
+
+    renderWithSwr(<ProceduresDetailedSummary patient={mockPatient} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /procedures/i })).toBeInTheDocument();
+    expect(screen.getByTestId('empty-card-illustration')).toBeInTheDocument();
+    expect(screen.getByText(/There are no procedures to display/i)).toBeInTheDocument();
+  });
+
+  it('renders an error state view if there is a problem fetching procedures', async () => {
+    const error = {
+      message: 'You are not logged in',
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+      },
+    };
+
+    mockOpenmrsFetch.mockRejectedValueOnce(error);
+
+    renderWithSwr(<ProceduresDetailedSummary patient={mockPatient} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByText('Error State')).toBeInTheDocument();
+  });
+
+  it("renders a detailed summary of all the patient's procedures without pagination", async () => {
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProceduresResponse } as FetchResponse);
+
+    renderWithSwr(<ProceduresDetailedSummary patient={mockPatient} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('heading', { name: /procedures/i })).toBeInTheDocument();
+
+    const expectedColumnHeaders = ['Procedure', 'Procedure type', 'Body site', 'Start date', 'End date', 'Status'];
+    expectedColumnHeaders.forEach((header) => {
+      expect(screen.getByRole('button', { name: header })).toBeInTheDocument();
+    });
+
+    // All 6 procedures should be displayed
+    const expectedTableRows = [/appendectomy/i, /colonoscopy/i, /blood draw/i, /chest x-ray/i, /ecg/i, /mri brain/i];
+    expectedTableRows.forEach((row) => {
+      expect(screen.getByRole('row', { name: row })).toBeInTheDocument();
+    });
+
+    // Header row + 6 data rows + 6 collapsed expanded rows (CSS not loaded in Jest) = 13
+    expect(screen.getAllByRole('row').length).toEqual(13);
+    expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+  });
+
+  it('renders duration and notes in the expanded row', async () => {
+    const user = userEvent.setup();
+
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProceduresResponse } as FetchResponse);
+
+    renderWithSwr(<ProceduresDetailedSummary patient={mockPatient} />);
+
+    await waitForLoadingToFinish();
+
+    const expandButtons = screen.getAllByRole('button', { name: /expand current row/i });
+    await user.click(expandButtons[0]);
+
+    expect(screen.getByText(/45 Minutes/i)).toBeInTheDocument();
+    expect(screen.getByText(/Procedure went well/i)).toBeInTheDocument();
+  });
+
+  it('renders an "Add" button that launches the procedures form workspace', async () => {
+    const user = userEvent.setup();
+
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProceduresResponse } as FetchResponse);
+
+    renderWithSwr(<ProceduresDetailedSummary patient={mockPatient} />);
+
+    await waitForLoadingToFinish();
+
+    const addButton = screen.getByRole('button', { name: /add/i });
+    expect(addButton).toBeInTheDocument();
+
+    await user.click(addButton);
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('procedures-form-workspace', { formContext: 'creating' });
+  });
+});

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-detailed-summary.component.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Button,
+  DataTable,
+  DataTableSkeleton,
+  InlineLoading,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableExpandedRow,
+  TableExpandHeader,
+  TableExpandRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tile,
+} from '@carbon/react';
+import { Add } from '@carbon/react/icons';
+import {
+  formatDate,
+  isDesktop as isDesktopLayout,
+  launchWorkspace2,
+  parseDate,
+  useLayoutType,
+  CardHeader,
+  EmptyCard,
+  ErrorState,
+  formatPartialDate,
+} from '@openmrs/esm-framework';
+import { useProcedures } from './procedures.resource';
+import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+import styles from './procedures-overview.scss';
+import { ProceduresActionMenu } from './procedures-action-menu.component';
+
+const DEFAULT_PAGE_SIZE = 20;
+
+type ProceduresDetailedSummaryProps = {
+  patient: fhir.Patient;
+};
+
+type ProcedureTableRow = {
+  id: string;
+  display: string;
+  procedureType: string;
+  bodySite: string;
+  startDateTimeRender: string;
+  estimatedStartDate?: string;
+  endDateTimeRender: string;
+  status: string;
+  notes?: string;
+};
+
+function ProceduresDetailedSummary({ patient }: ProceduresDetailedSummaryProps) {
+  const { t } = useTranslation();
+  const headerTitle = t('procedures', 'Procedures');
+  const displayText = t('procedures_lower', 'procedures');
+  const layout = useLayoutType();
+  const isDesktop = isDesktopLayout(layout);
+  const launchProceduresForm = useCallback(
+    () => launchWorkspace2('procedures-form-workspace', { formContext: 'creating' }),
+    [],
+  );
+
+  const { procedures, error, isLoading, isValidating } = useProcedures(patient.id);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+  const headers = useMemo(
+    () => [
+      { key: 'display', header: t('procedure', 'Procedure') },
+      { key: 'procedureType', header: t('procedureType', 'Procedure type') },
+      { key: 'bodySite', header: t('bodySite', 'Body site') },
+      { key: 'startDateTimeRender', header: t('startDate', 'Start date') },
+      { key: 'endDateTimeRender', header: t('endDate', 'End date') },
+      { key: 'status', header: t('status', 'Status') },
+    ],
+    [t],
+  );
+
+  const allRows: ProcedureTableRow[] = useMemo(
+    () =>
+      procedures?.map((p) => ({
+        id: p.uuid,
+        display: p.display,
+        procedureType: p.procedureType.name,
+        bodySite: p.bodySite.display ?? '--',
+        startDateTimeRender: p.estimatedStartDate ?? p.startDateTime,
+        estimatedStartDate: p.estimatedStartDate,
+        endDateTimeRender: p.endDateTime ? formatDate(parseDate(p.endDateTime), { mode: 'wide' }) : '--',
+        status: p.status.display,
+        notes: p.notes,
+      })),
+    [procedures],
+  );
+
+  const tableRows = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return allRows?.slice(start, start + pageSize);
+  }, [allRows, currentPage, pageSize]);
+
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" zebra />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} headerTitle={headerTitle} />;
+  }
+
+  if (procedures?.length) {
+    return (
+      <div className={styles.widgetCard}>
+        <CardHeader title={headerTitle}>
+          <span>{isValidating ? <InlineLoading /> : null}</span>
+          <Button
+            kind="ghost"
+            renderIcon={(props) => <Add size={16} {...props} />}
+            iconDescription={t('addProcedure', 'Add procedure')}
+            onClick={launchProceduresForm}
+          >
+            {t('add', 'Add')}
+          </Button>
+        </CardHeader>
+        <DataTable
+          aria-label="procedures detailed summary"
+          headers={headers}
+          isSortable
+          overflowMenuOnHover={isDesktop}
+          rows={tableRows}
+          size={isDesktop ? 'sm' : 'lg'}
+          useZebraStyles
+        >
+          {({ rows, headers: carbonHeaders, getRowProps, getExpandedRowProps, getHeaderProps, getTableProps }) => (
+            <>
+              <TableContainer>
+                <Table {...getTableProps()} className={styles.table}>
+                  <TableHead>
+                    <TableRow>
+                      <TableExpandHeader aria-label="expand row" />
+                      {carbonHeaders.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })} key={header.key}>
+                          {header.header}
+                        </TableHeader>
+                      ))}
+                      <TableHeader />
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {rows.map((row) => {
+                      const matchingRow = tableRows?.find((r) => r.id === row.id);
+                      const matchingProcedure = procedures?.find((p) => p.uuid === row.id);
+                      return (
+                        <React.Fragment key={row.id}>
+                          <TableExpandRow {...getRowProps({ row })}>
+                            {row.cells.map((cell) => {
+                              if (cell.info.header === 'startDateTimeRender') {
+                                const display = matchingRow?.estimatedStartDate
+                                  ? `${formatPartialDate(matchingRow.estimatedStartDate, { mode: 'wide' })}*`
+                                  : formatDate(parseDate(cell.value), { mode: 'wide', time: true });
+                                return <TableCell key={cell.id}>{display}</TableCell>;
+                              }
+                              return <TableCell key={cell.id}>{cell.value}</TableCell>;
+                            })}
+                            <TableCell className="cds--table-column-menu">
+                              <ProceduresActionMenu procedure={matchingProcedure} patientUuid={patient.id} />
+                            </TableCell>
+                          </TableExpandRow>
+                          <TableExpandedRow
+                            colSpan={headers.length + 2}
+                            className="demo-expanded-td"
+                            {...getExpandedRowProps({ row })}
+                          >
+                            <p>
+                              <strong>{t('duration', 'Duration')}: </strong>
+                              {matchingProcedure?.duration
+                                ? `${matchingProcedure.duration} ${matchingProcedure.durationUnit?.display ?? ''}`
+                                : '--'}
+                            </p>
+                            <p>
+                              <strong>{t('notes', 'Notes')}: </strong>
+                              {matchingRow?.notes ?? '--'}
+                            </p>
+                          </TableExpandedRow>
+                        </React.Fragment>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              {rows.length === 0 ? (
+                <div className={styles.tileContainer}>
+                  <Tile className={styles.tile}>
+                    <div className={styles.tileContent}>
+                      <p className={styles.content}>{t('noProceduresToDisplay', 'No procedures to display')}</p>
+                    </div>
+                  </Tile>
+                </div>
+              ) : null}
+              <PatientChartPagination
+                currentItems={rows.length}
+                totalItems={allRows?.length ?? 0}
+                pageNumber={currentPage}
+                pageSize={pageSize}
+                onPageNumberChange={({ page, pageSize: newPageSize }: { page: number; pageSize: number }) => {
+                  setCurrentPage(page);
+                  setPageSize(newPageSize);
+                }}
+              />
+            </>
+          )}
+        </DataTable>
+      </div>
+    );
+  }
+
+  return <EmptyCard displayText={displayText} headerTitle={headerTitle} launchForm={launchProceduresForm} />;
+}
+
+export default ProceduresDetailedSummary;

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.component.tsx
@@ -1,0 +1,476 @@
+import React, { useCallback, useState } from 'react';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+import {
+  Button,
+  ButtonSet,
+  ComboBox,
+  ContentSwitcher,
+  Form,
+  FormGroup,
+  InlineLoading,
+  InlineNotification,
+  Layer,
+  NumberInput,
+  Search,
+  Select,
+  SelectItem,
+  Stack,
+  Switch,
+  TextArea,
+  Tile,
+} from '@carbon/react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { ResponsiveWrapper, showSnackbar, useConfig, useLayoutType } from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
+import {
+  saveProcedure,
+  updateProcedure,
+  useConceptSearchField,
+  useMutatePatientProcedures,
+  useProcedureTypes,
+} from './procedures.resource';
+import { type ProceduresFormSchema } from './procedures-form.workspace';
+import { DateTimeField } from './date-time-field.component';
+import styles from './procedures-form.scss';
+import { type ProcedureType, type ConceptReference, type Procedure } from '../types';
+
+interface ProceduresFormComponentProps {
+  closeWorkspaceWithSavedChanges: () => void;
+  isSubmittingForm: boolean;
+  procedure?: Procedure;
+  patientUuid: string;
+}
+
+interface ConceptSearchResultsProps {
+  isSearching: boolean;
+  onSelect: (result: ConceptReference) => void;
+  searchResults: Array<ConceptReference>;
+  selectedItem: ConceptReference;
+  value: string;
+}
+
+const ProceduresFormComponent: React.FC<ProceduresFormComponentProps> = ({
+  closeWorkspaceWithSavedChanges,
+  patientUuid,
+  procedure,
+}) => {
+  const { t } = useTranslation();
+  const {
+    procedureCodedConceptClassUuid,
+    bodySiteConceptClassUuid,
+    statusConceptClassUuid,
+    durationUnitMinutesConceptUuid,
+    durationUnitHoursConceptUuid,
+    durationUnitDaysConceptUuid,
+  } = useConfig<ConfigObject>();
+  const mutate = useMutatePatientProcedures(patientUuid);
+
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+    getValues,
+    setValue,
+  } = useFormContext<ProceduresFormSchema>();
+
+  const { procedureTypes, isLoading: isLoadingProcedureTypes } = useProcedureTypes();
+
+  const isTablet = useLayoutType() === 'tablet';
+  const [isSubmittingForm, setIsSubmittingForm] = useState(false);
+  const [isStartDateKnown, setIsStartDateKnown] = useState(!getValues('estimatedStartDate'));
+  const initialEstimatedDate = getValues('estimatedStartDate');
+  const [estimatedYear, setEstimatedYear] = useState(initialEstimatedDate?.split('-')[0] ?? '');
+  const [estimatedMonth, setEstimatedMonth] = useState(initialEstimatedDate?.split('-')[1] ?? '');
+
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: currentYear - 1900 + 1 }, (_, i) => String(currentYear - i));
+  const months = [
+    { value: '01', label: 'January' },
+    { value: '02', label: 'February' },
+    { value: '03', label: 'March' },
+    { value: '04', label: 'April' },
+    { value: '05', label: 'May' },
+    { value: '06', label: 'June' },
+    { value: '07', label: 'July' },
+    { value: '08', label: 'August' },
+    { value: '09', label: 'September' },
+    { value: '10', label: 'October' },
+    { value: '11', label: 'November' },
+    { value: '12', label: 'December' },
+  ];
+
+  const procedureField = useConceptSearchField(procedureCodedConceptClassUuid, getValues('procedureCoded'));
+  const bodySiteField = useConceptSearchField(bodySiteConceptClassUuid, getValues('bodySite'));
+  const statusField = useConceptSearchField(statusConceptClassUuid, getValues('status'));
+
+  const [errorSaving, setErrorSaving] = useState(null);
+
+  const handleSave = useCallback(async () => {
+    const procedureType = getValues('procedureType');
+    const startDateTime = getValues('startDateTime');
+    const endDateTime = getValues('endDateTime');
+    const notes = getValues('notes');
+    const duration = getValues('duration');
+    const durationUnit = getValues('durationUnit');
+
+    let estimatedStartDate: string | undefined;
+    if (!isStartDateKnown && estimatedYear) {
+      estimatedStartDate = estimatedMonth ? `${estimatedYear}-${estimatedMonth}` : estimatedYear;
+    }
+
+    const hasDuration = typeof duration === 'number' && !Number.isNaN(duration);
+
+    const payload = {
+      patient: patientUuid,
+      procedureCoded: procedureField.selectedConcept!.uuid,
+      procedureType: procedureType,
+      bodySite: bodySiteField.selectedConcept!.uuid,
+      startDateTime: isStartDateKnown && startDateTime ? dayjs(startDateTime).format() : null,
+      endDateTime: endDateTime ? dayjs(endDateTime).format() : null,
+      status: statusField.selectedConcept?.uuid,
+      notes: notes,
+      estimatedStartDate: estimatedStartDate || null,
+      duration: hasDuration ? duration : null,
+      durationUnit: hasDuration && durationUnit ? durationUnit : null,
+    };
+
+    try {
+      if (procedure?.uuid) {
+        await updateProcedure(procedure.uuid, payload);
+      } else {
+        await saveProcedure(payload);
+      }
+      await mutate();
+      showSnackbar({
+        kind: 'success',
+        title: t('procedureSaved', 'Procedure saved'),
+        subtitle: t('procedureNowVisible', 'It is now visible on the Procedures page'),
+      });
+      closeWorkspaceWithSavedChanges();
+    } catch (error) {
+      setIsSubmittingForm(false);
+      setErrorSaving(error);
+    }
+  }, [
+    bodySiteField.selectedConcept,
+    closeWorkspaceWithSavedChanges,
+    estimatedMonth,
+    estimatedYear,
+    getValues,
+    isStartDateKnown,
+    mutate,
+    patientUuid,
+    procedureField.selectedConcept,
+    statusField.selectedConcept,
+    procedure?.uuid,
+    t,
+  ]);
+
+  const onError = () => setIsSubmittingForm(false);
+
+  return (
+    <Form className={styles.form} onSubmit={handleSubmit(handleSave, onError)}>
+      <div className={styles.formContainer}>
+        <Stack gap={7}>
+          <FormGroup legendText={<RequiredFieldLabel label={t('procedure', 'Procedure')} />}>
+            <ConceptSearchField
+              label={t('enterProcedure', 'Enter procedure')}
+              placeholder={t('searchProcedures', 'Search procedures')}
+              field={procedureField}
+              onChange={(selectedConcept) => setValue('procedureCoded', selectedConcept.uuid)}
+            />
+            {errors.procedureCoded && <p className={styles.errorMessage}>{errors.procedureCoded.message}</p>}
+          </FormGroup>
+
+          <FormGroup legendText={<RequiredFieldLabel label={t('procedureType', 'Procedure type')} />}>
+            {isLoadingProcedureTypes ? (
+              <InlineLoading className={styles.loader} description={t('loading', 'Loading') + '...'} />
+            ) : (
+              <ResponsiveWrapper>
+                <ComboBox
+                  id="procedureType"
+                  titleText=""
+                  placeholder={t('selectProcedureType', 'Select procedure type')}
+                  items={procedureTypes}
+                  itemToString={(item: ProcedureType) => item?.name ?? ''}
+                  initialSelectedItem={procedureTypes.find((pt) => pt.uuid === getValues('procedureType')) ?? null}
+                  onChange={({ selectedItem }: { selectedItem: ProcedureType | null }) =>
+                    setValue('procedureType', selectedItem.uuid)
+                  }
+                />
+              </ResponsiveWrapper>
+            )}
+            {errors.procedureType && <p className={styles.errorMessage}>{errors.procedureType.message}</p>}
+          </FormGroup>
+
+          <FormGroup legendText={<RequiredFieldLabel label={t('bodySite', 'Body site')} />}>
+            <ConceptSearchField
+              label={t('enterBodySite', 'Enter body site')}
+              placeholder={t('searchBodySites', 'Search body sites')}
+              field={bodySiteField}
+              onChange={(selectedConcept) => setValue('bodySite', selectedConcept.uuid)}
+            />
+            {errors.bodySite && <p className={styles.errorMessage}>{errors.bodySite.message}</p>}
+          </FormGroup>
+          <FormGroup legendText={t('isStartDateKnown', 'Is start date known?')}>
+            <ContentSwitcher
+              size="md"
+              selectedIndex={isStartDateKnown ? 0 : 1}
+              onChange={({ index }: { index: number }) => {
+                setIsStartDateKnown(index === 0);
+                setEstimatedYear('');
+                setEstimatedMonth('');
+              }}
+            >
+              <Switch name="yes">{t('yes', 'Yes')}</Switch>
+              <Switch name="no">{t('no', 'No')}</Switch>
+            </ContentSwitcher>
+          </FormGroup>
+
+          {isStartDateKnown && (
+            <FormGroup legendText={t('startDateAndTime', 'Start date and time')}>
+              <DateTimeField name="startDateTime" idPrefix="startDateTime" control={control} />
+              {errors.startDateTime && <p className={styles.errorMessage}>{errors.startDateTime.message}</p>}
+            </FormGroup>
+          )}
+
+          {!isStartDateKnown && (
+            <FormGroup legendText={t('estimatedStartDate', 'Estimated start date')}>
+              <ResponsiveWrapper>
+                <Select
+                  id="estimatedYear"
+                  labelText={<RequiredFieldLabel label={t('year', 'Year')} />}
+                  value={estimatedYear}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setEstimatedYear(e.target.value)}
+                >
+                  <SelectItem value="" text={t('selectYear', 'Select year')} />
+                  {years.map((year) => (
+                    <SelectItem key={year} value={year} text={year} />
+                  ))}
+                </Select>
+              </ResponsiveWrapper>
+              <ResponsiveWrapper>
+                <Select
+                  id="estimatedMonth"
+                  labelText={t('monthOptional', 'Month (optional)')}
+                  value={estimatedMonth}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setEstimatedMonth(e.target.value)}
+                >
+                  <SelectItem value="" text={t('selectMonth', 'Select month (optional)')} />
+                  {months.map((month) => (
+                    <SelectItem key={month.value} value={month.value} text={month.label} />
+                  ))}
+                </Select>
+              </ResponsiveWrapper>
+            </FormGroup>
+          )}
+
+          <FormGroup legendText={t('endDateAndTime', 'End date and time')}>
+            <DateTimeField name="endDateTime" idPrefix="endDateTime" control={control} />
+            {errors.endDateTime && <p className={styles.errorMessage}>{errors.endDateTime.message}</p>}
+          </FormGroup>
+
+          <FormGroup legendText={t('duration', 'Duration')}>
+            <div className={styles.durationFieldGroup}>
+              <Controller
+                name="duration"
+                control={control}
+                render={({ field: { onChange, value, ref, name } }) => (
+                  <ResponsiveWrapper>
+                    <NumberInput
+                      id="duration"
+                      name={name}
+                      ref={ref}
+                      label={t('durationValue', 'Duration')}
+                      placeholder={t('enterDuration', 'Enter duration')}
+                      min={1}
+                      hideSteppers
+                      allowEmpty
+                      value={value ?? ''}
+                      onChange={(_event, { value: nextValue }: { value: number | string }) => {
+                        if (nextValue == null || nextValue === '') {
+                          onChange(null);
+                          return;
+                        }
+                        const parsed = typeof nextValue === 'number' ? nextValue : Number(nextValue);
+                        onChange(Number.isNaN(parsed) ? null : parsed);
+                      }}
+                    />
+                  </ResponsiveWrapper>
+                )}
+              />
+              <Controller
+                name="durationUnit"
+                control={control}
+                render={({ field }) => (
+                  <ResponsiveWrapper>
+                    <Select
+                      id="durationUnit"
+                      labelText={t('durationUnit', 'Duration unit')}
+                      value={field.value ?? ''}
+                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => field.onChange(e.target.value)}
+                    >
+                      <SelectItem value="" text={t('selectDurationUnit', 'Select unit')} />
+                      <SelectItem value={durationUnitMinutesConceptUuid} text={t('minutes', 'Minutes')} />
+                      <SelectItem value={durationUnitHoursConceptUuid} text={t('hours', 'Hours')} />
+                      <SelectItem value={durationUnitDaysConceptUuid} text={t('days', 'Days')} />
+                    </Select>
+                  </ResponsiveWrapper>
+                )}
+              />
+            </div>
+            {errors.duration && <p className={styles.errorMessage}>{errors.duration.message}</p>}
+            {errors.durationUnit && <p className={styles.errorMessage}>{errors.durationUnit.message}</p>}
+          </FormGroup>
+
+          <FormGroup legendText={<RequiredFieldLabel label={t('status', 'Status')} />}>
+            <ConceptSearchField
+              label={t('enterStatus', 'Enter status')}
+              placeholder={t('searchStatus', 'Search status')}
+              field={statusField}
+              onChange={(selectedConcept) => setValue('status', selectedConcept.uuid)}
+            />
+            {errors.status && <p className={styles.errorMessage}>{errors.status.message}</p>}
+          </FormGroup>
+
+          <FormGroup legendText={t('notes', 'Notes')}>
+            <Controller
+              name="notes"
+              control={control}
+              render={({ field }) => (
+                <ResponsiveWrapper>
+                  <TextArea
+                    {...field}
+                    id="notes"
+                    labelText=""
+                    placeholder={t('enterNotes', 'Enter notes (optional)')}
+                  />
+                </ResponsiveWrapper>
+              )}
+            />
+            {errors.notes && <p className={styles.errorMessage}>{errors.notes.message}</p>}
+          </FormGroup>
+        </Stack>
+      </div>
+      <div>
+        {errorSaving ? (
+          <div className={styles.errorContainer}>
+            <InlineNotification
+              role="alert"
+              kind="error"
+              lowContrast
+              title={t('errorSavingProcedure', 'Error saving procedure')}
+              subtitle={errorSaving?.message}
+            />
+          </div>
+        ) : null}
+        <ButtonSet className={classNames({ [styles.tablet]: isTablet, [styles.desktop]: !isTablet })}>
+          <Button className={styles.button} kind="secondary" onClick={() => closeWorkspaceWithSavedChanges()}>
+            {t('cancel', 'Cancel')}
+          </Button>
+          <Button className={styles.button} disabled={isSubmittingForm} kind="primary" type="submit">
+            {isSubmittingForm ? (
+              <InlineLoading className={styles.spinner} description={t('saving', 'Saving') + '...'} />
+            ) : (
+              <span>{t('saveAndClose', 'Save & close')}</span>
+            )}
+          </Button>
+        </ButtonSet>
+      </div>
+    </Form>
+  );
+};
+
+function RequiredFieldLabel({ label }: { label: string }) {
+  const { t } = useTranslation();
+  return (
+    <span>
+      {label}
+      <span title={t('required', 'Required')} className={styles.required}>
+        *
+      </span>
+    </span>
+  );
+}
+
+function ConceptSearchField({
+  label,
+  placeholder,
+  field,
+  onChange,
+}: {
+  label: string;
+  placeholder: string;
+  field: ReturnType<typeof useConceptSearchField>;
+  onChange: (selectedConcept: ConceptReference) => void;
+}) {
+  return (
+    <>
+      <ResponsiveWrapper>
+        <Search
+          labelText={label}
+          placeholder={placeholder}
+          onChange={(e) => field.setSearchTerm(e.target.value)}
+          onClear={field.clear}
+          value={field.selectedConcept ? field.selectedConcept.display : field.searchTerm}
+        />
+      </ResponsiveWrapper>
+
+      <ConceptSearchResults
+        isSearching={field.isSearching}
+        searchResults={field.searchResults}
+        selectedItem={field.selectedConcept}
+        value={field.searchTerm}
+        onSelect={(result) => {
+          field.setSelectedConcept(result);
+          field.setSearchTerm('');
+          onChange(result);
+        }}
+      />
+    </>
+  );
+}
+
+function ConceptSearchResults({
+  isSearching,
+  onSelect,
+  searchResults,
+  selectedItem,
+  value,
+}: ConceptSearchResultsProps) {
+  const { t } = useTranslation();
+
+  if (!value || selectedItem) {
+    return null;
+  }
+
+  if (isSearching) {
+    return <InlineLoading className={styles.loader} description={t('searching', 'Searching') + '...'} />;
+  }
+
+  if (searchResults?.length > 0) {
+    return (
+      <ul className={styles.resultsList}>
+        {searchResults.map((result) => (
+          <li className={styles.resultItem} key={result.uuid} onClick={() => onSelect(result)} role="menuitem">
+            {result.display}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  return (
+    <Layer>
+      <Tile className={styles.emptyResults}>
+        <span>
+          {t('noResultsFor', 'No results for')} <strong>"{value}"</strong>
+        </span>
+      </Tile>
+    </Layer>
+  );
+}
+
+export default ProceduresFormComponent;

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.scss
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.scss
@@ -1,0 +1,106 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '@openmrs/esm-styleguide/src/vars' as *;
+
+.resultItem {
+  padding: layout.$spacing-04;
+  border-top: 0.0625rem solid $grey-2;
+
+  &:first-of-type {
+    border-top: none;
+  }
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+}
+
+.resultsList {
+  background-color: $ui-02;
+  max-height: 14rem;
+  overflow-y: auto;
+  border: 1px solid $ui-03;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li:hover {
+    background-color: $ui-03;
+    cursor: pointer;
+  }
+}
+
+.emptyResults {
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+  min-height: layout.$spacing-05;
+  border: 1px solid $ui-03;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.formContainer {
+  margin: layout.$spacing-05;
+}
+
+.button {
+  height: layout.$spacing-10;
+  display: flex;
+  align-content: flex-start;
+  align-items: baseline;
+  min-width: 50%;
+}
+
+.tablet {
+  padding: layout.$spacing-06 layout.$spacing-05;
+  background-color: $ui-02;
+}
+
+.desktop {
+  padding: 0;
+}
+
+.loader {
+  padding: layout.$spacing-05 layout.$spacing-03;
+}
+
+.errorContainer {
+  margin: layout.$spacing-05;
+}
+
+.errorMessage {
+  @include type.type-style('label-02');
+  color: $danger;
+  margin-top: layout.$spacing-03;
+}
+
+.spinner {
+  &:global(.cds--inline-loading) {
+    min-height: layout.$spacing-05;
+  }
+}
+
+.required {
+  color: colors.$red-60;
+  margin-left: layout.$spacing-01;
+}
+
+.durationFieldGroup {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: layout.$spacing-05;
+  align-items: end;
+}
+
+.dateTimeFieldGroup {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: layout.$spacing-05;
+  align-items: end;
+}

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.test.tsx
@@ -1,0 +1,456 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  type FetchResponse,
+  getDefaultsFromConfigSchema,
+  openmrsFetch,
+  showSnackbar,
+  useConfig,
+} from '@openmrs/esm-framework';
+import { type PatientWorkspace2DefinitionProps } from '@openmrs/esm-patient-common-lib';
+import { mockPatient } from 'tools';
+import { mockProcedureTypes, mockProceduresResponse, searchedProcedure } from '__mocks__';
+import { type ConfigObject, configSchema } from '../config-schema';
+import { saveProcedure, useConceptSearch, useConceptSearchField, useProcedureTypes } from './procedures.resource';
+import ProceduresForm, { type ProceduresFormProps } from './procedures-form.workspace';
+import { type ConceptReference } from '../types';
+
+jest.mock('./procedures.resource', () => ({
+  ...jest.requireActual('./procedures.resource'),
+  saveProcedure: jest.fn(),
+  useConceptSearch: jest.fn(),
+  useConceptSearchField: jest.fn(),
+  useProcedureTypes: jest.fn(),
+  useMutatePatientProcedures: jest.fn(() => jest.fn()),
+  useProcedures: jest.fn(),
+}));
+
+const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
+const mockSaveProcedure = jest.mocked(saveProcedure);
+const mockShowSnackbar = jest.mocked(showSnackbar);
+const mockUseConceptSearch = jest.mocked(useConceptSearch);
+const mockUseConceptSearchField = jest.mocked(useConceptSearchField);
+const mockUseProcedureTypes = jest.mocked(useProcedureTypes);
+
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  procedurePageSize: 5,
+  procedureCodedConceptClassUuid: '',
+  bodySiteConceptClassUuid: '',
+  statusConceptClassUuid: '',
+  durationUnitMinutesConceptUuid: 'minutes-uuid',
+  durationUnitHoursConceptUuid: 'hours-uuid',
+  durationUnitDaysConceptUuid: 'days-uuid',
+});
+
+const defaultProps: PatientWorkspace2DefinitionProps<ProceduresFormProps, object> = {
+  closeWorkspace: jest.fn(),
+  groupProps: {
+    patientUuid: mockPatient.id,
+    patient: mockPatient,
+    visitContext: null,
+    mutateVisitContext: null,
+  },
+  workspaceName: '',
+  launchChildWorkspace: jest.fn(),
+  workspaceProps: { formContext: 'creating' },
+  windowProps: {},
+  windowName: '',
+  isRootWorkspace: false,
+  showActionMenu: true,
+};
+
+function renderProceduresForm() {
+  render(<ProceduresForm {...defaultProps} />);
+}
+
+async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+  // The shared mockUseConceptSearch returns the same searchedProcedure mock
+  // for every concept search field, so each "Appendectomy" menuitem matches the
+  // currently-typed-in field — only one results list is visible at a time.
+  await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
+  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+
+  await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
+  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+
+  await user.type(screen.getByRole('searchbox', { name: /enter status/i }), 'Done');
+  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+
+  const procedureTypeGroup = screen.getByRole('group', { name: /procedure type/i });
+  await user.click(within(procedureTypeGroup).getByRole('combobox'));
+  await user.click(screen.getByRole('option', { name: /surgery/i }));
+}
+
+beforeEach(() => {
+  mockUseProcedureTypes.mockReturnValue({ procedureTypes: mockProcedureTypes, isLoading: false });
+  mockUseConceptSearch.mockReturnValue({ searchResults: [], isSearching: false });
+  mockOpenmrsFetch.mockResolvedValue({ data: { results: [] } } as FetchResponse);
+  mockUseConceptSearchField.mockImplementation(() => {
+    const [searchTerm, setSearchTerm] = React.useState('');
+    const [selectedConcept, setSelectedConcept] = React.useState<ConceptReference | null>(null);
+    const { searchResults, isSearching } = mockUseConceptSearch(searchTerm, '');
+    return {
+      searchTerm,
+      setSearchTerm,
+      selectedConcept,
+      setSelectedConcept,
+      searchResults,
+      isSearching,
+      clear: () => {
+        setSearchTerm('');
+        setSelectedConcept(null);
+      },
+    };
+  });
+});
+
+describe('ProceduresForm', () => {
+  it('renders all form fields', () => {
+    renderProceduresForm();
+
+    expect(screen.getByRole('searchbox', { name: /enter procedure/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /procedure type/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /body site/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /start date and time/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /end date and time/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /^duration$/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /^status/i })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /notes/i })).toBeInTheDocument();
+  });
+
+  it('renders Cancel and Save & close buttons', () => {
+    renderProceduresForm();
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    const submitButton = screen.getByRole('button', { name: /save & close/i });
+    expect(cancelButton).toBeInTheDocument();
+    expect(cancelButton).toBeEnabled();
+    expect(submitButton).toBeInTheDocument();
+    expect(submitButton).toBeEnabled();
+  });
+
+  it('calls closeWorkspace when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderProceduresForm();
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.closeWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a validation error when submitting without a procedure', async () => {
+    const user = userEvent.setup();
+    renderProceduresForm();
+
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    expect(screen.getByText(/a procedure is required/i)).toBeInTheDocument();
+  });
+
+  it('renders search results as the user types in the procedure search box', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+
+    renderProceduresForm();
+
+    await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
+
+    expect(screen.getByRole('menuitem', { name: /appendectomy/i })).toBeInTheDocument();
+  });
+
+  it('shows a "No results" tile when a search yields no matches', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: [], isSearching: false });
+
+    renderProceduresForm();
+
+    await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'Xyz123');
+
+    expect(screen.getByText(/no results for/i)).toBeInTheDocument();
+  });
+
+  it('shows a loading indicator while searching', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: [], isSearching: true });
+
+    renderProceduresForm();
+
+    await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
+
+    expect(screen.getByText(/searching/i)).toBeInTheDocument();
+  });
+
+  it('displays procedure types in the ComboBox', async () => {
+    const user = userEvent.setup();
+    renderProceduresForm();
+
+    // The ComboBox input is within the "Procedure type" group
+    const procedureTypeGroup = screen.getByRole('group', { name: /procedure type/i });
+    const combobox = within(procedureTypeGroup).getByRole('combobox');
+    expect(combobox).toBeInTheDocument();
+
+    // Open the dropdown and expect items to appear
+    await user.click(combobox);
+    expect(screen.getByRole('option', { name: /surgery/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /endoscopy/i })).toBeInTheDocument();
+  });
+
+  it('shows a loading indicator for procedure types while loading', () => {
+    mockUseProcedureTypes.mockReturnValue({ procedureTypes: [], isLoading: true });
+    renderProceduresForm();
+
+    expect(screen.getAllByText(/loading/i).length).toBeGreaterThan(0);
+  });
+
+  it('calls saveProcedure with the correct payload on submission', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith({
+        patient: mockPatient.id,
+        procedureCoded: 'proc-concept-uuid-1',
+        procedureType: 'pt-uuid-1',
+        bodySite: 'proc-concept-uuid-1',
+        startDateTime: null,
+        endDateTime: null,
+        status: 'proc-concept-uuid-1',
+        notes: '',
+        estimatedStartDate: null,
+        duration: null,
+        durationUnit: null,
+      }),
+    );
+  });
+
+  it('includes notes in the payload when provided', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.type(screen.getByPlaceholderText(/enter notes/i), 'Some clinical notes');
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith(expect.objectContaining({ notes: 'Some clinical notes' })),
+    );
+  });
+
+  it('includes the selected procedure type in the payload', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith(expect.objectContaining({ procedureType: 'pt-uuid-1' })),
+    );
+  });
+
+  it('closes the workspace after a successful save', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() => expect(defaultProps.closeWorkspace).toHaveBeenCalledWith({ discardUnsavedChanges: true }));
+  });
+
+  it('shows a success snackbar after successfully saving a procedure', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+    mockOpenmrsFetch.mockResolvedValue({ data: mockProceduresResponse } as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() => expect(mockShowSnackbar).toHaveBeenCalled());
+    expect(mockShowSnackbar).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'success', title: 'Procedure saved' }),
+    );
+  });
+
+  it('includes duration and duration unit in the payload when provided', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+
+    const durationInput = screen.getByRole('spinbutton', { name: /^duration$/i });
+    await user.type(durationInput, '30');
+
+    const unitSelect = screen.getByLabelText(/duration unit/i);
+    await user.selectOptions(unitSelect, 'minutes-uuid');
+
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith(
+        expect.objectContaining({ duration: 30, durationUnit: 'minutes-uuid' }),
+      ),
+    );
+  });
+
+  it('requires a duration unit when a duration value is entered', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+
+    renderProceduresForm();
+
+    await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
+    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+
+    const durationInput = screen.getByRole('spinbutton', { name: /^duration$/i });
+    await user.type(durationInput, '5');
+
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    expect(await screen.findByText(/duration unit is required/i)).toBeInTheDocument();
+    expect(mockSaveProcedure).not.toHaveBeenCalled();
+  });
+
+  it('renders Carbon TimePicker inputs alongside the start and end date pickers', () => {
+    renderProceduresForm();
+
+    const startGroup = screen.getByRole('group', { name: /start date and time/i });
+    expect(within(startGroup).getByLabelText(/^date$/i)).toBeInTheDocument();
+    expect(within(startGroup).getByLabelText(/^time$/i)).toBeInTheDocument();
+    expect(within(startGroup).getByLabelText(/am\/pm/i)).toBeInTheDocument();
+
+    const endGroup = screen.getByRole('group', { name: /end date and time/i });
+    expect(within(endGroup).getByLabelText(/^date$/i)).toBeInTheDocument();
+    expect(within(endGroup).getByLabelText(/^time$/i)).toBeInTheDocument();
+    expect(within(endGroup).getByLabelText(/am\/pm/i)).toBeInTheDocument();
+  });
+
+  it('disables the TimePicker and AM/PM select until a date is picked', async () => {
+    const user = userEvent.setup();
+    renderProceduresForm();
+
+    const startGroup = screen.getByRole('group', { name: /start date and time/i });
+    const startTimeInput = within(startGroup).getByLabelText(/^time$/i);
+    const startMeridiemSelect = within(startGroup).getByLabelText(/am\/pm/i);
+    expect(startTimeInput).toBeDisabled();
+    expect(startMeridiemSelect).toBeDisabled();
+
+    const startDateInput = within(startGroup).getByLabelText(/^date$/i);
+    await user.click(startDateInput);
+    await user.paste('2026-04-27');
+
+    expect(startTimeInput).toBeEnabled();
+    expect(startMeridiemSelect).toBeEnabled();
+  });
+
+  it('submits the combined date and time as an ISO datetime using the AM/PM selection', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
+    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
+    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.type(screen.getByRole('searchbox', { name: /enter status/i }), 'Done');
+    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+
+    const procedureTypeGroup = screen.getByRole('group', { name: /procedure type/i });
+    await user.click(within(procedureTypeGroup).getByRole('combobox'));
+    await user.click(screen.getByRole('option', { name: /surgery/i }));
+
+    const startGroup = screen.getByRole('group', { name: /start date and time/i });
+    await user.click(within(startGroup).getByLabelText(/^date$/i));
+    await user.paste('2026-04-27');
+    await user.type(within(startGroup).getByLabelText(/^time$/i), '02:30');
+    await user.selectOptions(within(startGroup).getByLabelText(/am\/pm/i), 'PM');
+
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDateTime: expect.stringMatching(/^2026-04-27T14:30/),
+        }),
+      ),
+    );
+  });
+
+  it('keeps morning hours unchanged when AM is the selected meridiem', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockResolvedValue({ status: 201 } as unknown as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+
+    const startGroup = screen.getByRole('group', { name: /start date and time/i });
+    await user.click(within(startGroup).getByLabelText(/^date$/i));
+    await user.paste('2026-04-27');
+    await user.type(within(startGroup).getByLabelText(/^time$/i), '09:15');
+
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await waitFor(() =>
+      expect(mockSaveProcedure).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDateTime: expect.stringMatching(/^2026-04-27T09:15/),
+        }),
+      ),
+    );
+  });
+
+  it('shows an error notification when saving fails', async () => {
+    const user = userEvent.setup();
+
+    mockUseConceptSearch.mockReturnValue({ searchResults: searchedProcedure, isSearching: false });
+    mockSaveProcedure.mockRejectedValue(new Error('Internal Server Error'));
+    mockOpenmrsFetch.mockResolvedValue({ data: { results: [] } } as FetchResponse);
+
+    renderProceduresForm();
+
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole('button', { name: /save & close/i }));
+
+    await screen.findByText(/error saving procedure/i);
+    expect(screen.getByText(/internal server error/i)).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-form.workspace.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useForm, FormProvider } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Workspace2 } from '@openmrs/esm-framework';
+import { type PatientWorkspace2DefinitionProps } from '@openmrs/esm-patient-common-lib';
+import ProceduresFormComponent from './procedures-form.component';
+import { type Procedure } from '../types';
+
+export type ProceduresFormProps = {
+  procedure?: Procedure;
+  formContext: 'creating' | 'editing';
+};
+
+const schema = z
+  .object({
+    procedureCoded: z.string().min(1, 'A procedure is required'),
+    procedureType: z.string().min(1, 'Procedure type is required'),
+    bodySite: z.string().min(1, 'Body site is required'),
+    startDateTime: z.date().optional().nullable(),
+    endDateTime: z.date().optional().nullable(),
+    status: z.string().min(1, 'Status is required'),
+    notes: z.string().optional(),
+    estimatedStartDate: z.string().optional(),
+    duration: z.number().int().positive('Duration must be a positive number').nullable().optional(),
+    durationUnit: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.startDateTime && data.endDateTime) {
+        return data.endDateTime >= data.startDateTime;
+      }
+      return true;
+    },
+    { message: 'End date must be on or after start date', path: ['endDateTime'] },
+  )
+  .refine(
+    (data) => {
+      const hasDuration = data.duration != null;
+      return !hasDuration || Boolean(data.durationUnit);
+    },
+    { message: 'Duration unit is required when a duration is provided', path: ['durationUnit'] },
+  );
+
+export type ProceduresFormSchema = z.infer<typeof schema>;
+
+const ProceduresForm: React.FC<PatientWorkspace2DefinitionProps<ProceduresFormProps, object>> = ({
+  closeWorkspace,
+  groupProps: { patientUuid },
+  workspaceProps: { procedure, formContext },
+}) => {
+  const { t } = useTranslation();
+  const [isSubmittingForm, setIsSubmittingForm] = useState(false);
+
+  const methods = useForm<ProceduresFormSchema>({
+    mode: 'all',
+    resolver: zodResolver(schema),
+    defaultValues: {
+      procedureCoded: procedure?.procedureCoded?.uuid ?? '',
+      procedureType: procedure?.procedureType?.uuid ?? '',
+      bodySite: procedure?.bodySite?.uuid ?? '',
+      startDateTime: procedure?.startDateTime ? new Date(procedure.startDateTime) : null,
+      endDateTime: procedure?.endDateTime ? new Date(procedure.endDateTime) : null,
+      status: procedure?.status?.uuid ?? '',
+      notes: procedure?.notes ?? '',
+      estimatedStartDate: procedure?.estimatedStartDate ?? '',
+      duration: typeof procedure?.duration === 'number' ? procedure.duration : null,
+      durationUnit: procedure?.durationUnit?.uuid ?? '',
+    },
+  });
+
+  const closeWorkspaceWithSavedChanges = useCallback(() => {
+    closeWorkspace({ discardUnsavedChanges: true });
+  }, [closeWorkspace]);
+
+  return (
+    <Workspace2
+      title={
+        formContext === 'editing' ? t('editProcedure', 'Edit procedure') : t('recordProcedure', 'Record procedure')
+      }
+      hasUnsavedChanges={methods.formState.isDirty}
+    >
+      <FormProvider {...methods}>
+        <ProceduresFormComponent
+          closeWorkspaceWithSavedChanges={closeWorkspaceWithSavedChanges}
+          isSubmittingForm={isSubmittingForm}
+          patientUuid={patientUuid}
+          procedure={procedure}
+        />
+      </FormProvider>
+    </Workspace2>
+  );
+};
+
+export default ProceduresForm;

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-overview.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-overview.component.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  type FetchResponse,
+  getDefaultsFromConfigSchema,
+  launchWorkspace2,
+  openmrsFetch,
+  useConfig,
+} from '@openmrs/esm-framework';
+import { type ConfigObject, configSchema } from '../config-schema';
+import { mockProceduresResponse } from '__mocks__';
+import { mockPatient, renderWithSwr, waitForLoadingToFinish } from 'tools';
+import ProceduresOverview from './procedures-overview.component';
+
+const mockUseConfig = jest.mocked(useConfig<ConfigObject>);
+const mockOpenmrsFetch = jest.mocked(openmrsFetch);
+const mockLaunchWorkspace2 = jest.mocked(launchWorkspace2);
+
+mockUseConfig.mockReturnValue({
+  ...getDefaultsFromConfigSchema(configSchema),
+  procedurePageSize: 5,
+});
+
+describe('ProceduresOverview', () => {
+  it('renders an empty state view if procedures data is unavailable', async () => {
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: { results: [] } } as FetchResponse);
+
+    renderWithSwr(<ProceduresOverview patientUuid={mockPatient.id} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /procedures/i })).toBeInTheDocument();
+    expect(screen.getByTestId('empty-card-illustration')).toBeInTheDocument();
+    expect(screen.getByText(/There are no procedures to display/i)).toBeInTheDocument();
+  });
+
+  it('renders an error state view if there is a problem fetching procedures', async () => {
+    const error = {
+      message: 'You are not logged in',
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+      },
+    };
+
+    mockOpenmrsFetch.mockRejectedValueOnce(error);
+
+    renderWithSwr(<ProceduresOverview patientUuid={mockPatient.id} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByText('Error State')).toBeInTheDocument();
+  });
+
+  it("renders a paginated overview of the patient's procedures", async () => {
+    const user = userEvent.setup();
+
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProceduresResponse } as FetchResponse);
+
+    renderWithSwr(<ProceduresOverview patientUuid={mockPatient.id} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('heading', { name: /procedures/i })).toBeInTheDocument();
+
+    const expectedColumnHeaders = [/^procedure$/i, /^date$/i];
+    expectedColumnHeaders.forEach((header) => {
+      expect(screen.getByRole('columnheader', { name: header })).toBeInTheDocument();
+    });
+
+    // First page: 5 rows visible
+    const firstPageRows = [/appendectomy/i, /colonoscopy/i, /blood draw/i, /chest x-ray/i, /ecg/i];
+    firstPageRows.forEach((row) => {
+      expect(screen.getByRole('row', { name: row })).toBeInTheDocument();
+    });
+
+    // Header row + 5 data rows = 6
+    expect(screen.getAllByRole('row').length).toEqual(6);
+    expect(screen.getByText(/5 \/ 6 items/i)).toBeInTheDocument();
+
+    const nextPageButton = screen.getByRole('button', { name: /next page/i });
+    await user.click(nextPageButton);
+
+    // Second page: 1 row
+    expect(screen.getByRole('row', { name: /mri brain/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('row').length).toEqual(2); // header + 1 data row
+  });
+
+  it('renders an "Add" button that launches the procedures form workspace', async () => {
+    const user = userEvent.setup();
+
+    mockOpenmrsFetch.mockResolvedValueOnce({ data: mockProceduresResponse } as FetchResponse);
+
+    renderWithSwr(<ProceduresOverview patientUuid={mockPatient.id} />);
+
+    await waitForLoadingToFinish();
+
+    const addButton = screen.getByRole('button', { name: /add/i });
+    expect(addButton).toBeInTheDocument();
+
+    await user.click(addButton);
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('procedures-form-workspace');
+  });
+
+  it('displays a non-coded procedure name when procedureCoded is absent', async () => {
+    mockOpenmrsFetch.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            uuid: 'proc-noncoded-1',
+            procedureNonCoded: 'Custom procedure',
+            startDateTime: '2021-08-01T00:00:00.000+0000',
+            voided: false,
+          },
+        ],
+        links: [],
+      },
+    } as FetchResponse);
+
+    renderWithSwr(<ProceduresOverview patientUuid={mockPatient.id} />);
+
+    await waitForLoadingToFinish();
+
+    expect(screen.getByRole('row', { name: /custom procedure/i })).toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-overview.component.tsx
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-overview.component.tsx
@@ -1,0 +1,148 @@
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Button,
+  DataTable,
+  DataTableSkeleton,
+  InlineLoading,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tile,
+} from '@carbon/react';
+import { Add } from '@carbon/react/icons';
+import {
+  formatDate,
+  isDesktop as isDesktopLayout,
+  launchWorkspace2,
+  parseDate,
+  useConfig,
+  useLayoutType,
+  usePagination,
+  CardHeader,
+  EmptyCard,
+  ErrorState,
+  formatPartialDate,
+} from '@openmrs/esm-framework';
+import { type ConfigObject } from '../config-schema';
+import { useProcedures } from './procedures.resource';
+import styles from './procedures-overview.scss';
+import { PatientChartPagination } from '@openmrs/esm-patient-common-lib';
+
+interface ProceduresOverviewProps {
+  patientUuid: string;
+}
+
+const ProceduresOverview: React.FC<ProceduresOverviewProps> = ({ patientUuid }) => {
+  const { procedurePageSize } = useConfig<ConfigObject>();
+  const { t } = useTranslation();
+  const launchProceduresForm = useCallback(() => launchWorkspace2('procedures-form-workspace'), []);
+  const headerTitle = t('procedures', 'Procedures');
+  const displayText = t('procedures_lower', 'procedures');
+  const pageUrl = `\${openmrsSpaBase}/patient/${patientUuid}/chart/Procedures`;
+  const urlLabel = t('seeAll', 'See all');
+  const layout = useLayoutType();
+  const isDesktop = isDesktopLayout(layout);
+
+  const { procedures, error, isLoading, isValidating } = useProcedures(patientUuid);
+
+  const headers = useMemo(
+    () => [
+      { key: 'display', header: t('procedure', 'Procedure') },
+      { key: 'startDateTimeRender', header: t('date', 'Date') },
+    ],
+    [t],
+  );
+
+  const tableRows = useMemo(
+    () =>
+      procedures?.map((p) => ({
+        id: p.uuid,
+        display: p.display ?? p.procedureNonCoded ?? '',
+        startDateTimeRender: p.estimatedStartDate
+          ? `${formatPartialDate(p.estimatedStartDate, { mode: 'wide' })}*`
+          : formatDate(parseDate(p.startDateTime), { mode: 'wide', time: true }),
+      })),
+    [procedures],
+  );
+
+  const { results: paginatedProcedures, goTo, currentPage } = usePagination(tableRows ?? [], procedurePageSize);
+
+  if (isLoading) {
+    return <DataTableSkeleton role="progressbar" zebra />;
+  }
+
+  if (error) {
+    return <ErrorState error={error} headerTitle={headerTitle} />;
+  }
+
+  if (procedures?.length) {
+    return (
+      <div className={styles.widgetCard}>
+        <CardHeader title={headerTitle}>
+          <span>{isValidating ? <InlineLoading /> : null}</span>
+          <Button
+            kind="ghost"
+            renderIcon={(props) => <Add size={16} {...props} />}
+            iconDescription={t('addProcedure', 'Add procedure')}
+            onClick={launchProceduresForm}
+          >
+            {t('add', 'Add')}
+          </Button>
+        </CardHeader>
+        <DataTable
+          aria-label="procedures overview"
+          headers={headers}
+          overflowMenuOnHover={isDesktop}
+          rows={paginatedProcedures}
+          size={isDesktop ? 'sm' : 'lg'}
+          useZebraStyles
+        >
+          {({ rows, headers, getHeaderProps, getTableProps }) => (
+            <>
+              <TableContainer className={styles.tableContainer}>
+                <Table {...getTableProps()} className={styles.table}>
+                  <TableHead>
+                    <TableRow>
+                      {headers.map((header) => (
+                        <TableHeader {...getHeaderProps({ header })} key={header.key}>
+                          {header.header}
+                        </TableHeader>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {rows.map((row) => (
+                      <TableRow key={row.id}>
+                        {row.cells.map((cell) => (
+                          <TableCell key={cell.id}>{cell.value}</TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </>
+          )}
+        </DataTable>
+        <PatientChartPagination
+          currentItems={paginatedProcedures.length}
+          onPageNumberChange={({ page }) => goTo(page)}
+          pageNumber={currentPage}
+          pageSize={procedurePageSize}
+          totalItems={procedures.length}
+          dashboardLinkUrl={pageUrl}
+          dashboardLinkLabel={urlLabel}
+        />
+      </div>
+    );
+  }
+
+  return <EmptyCard displayText={displayText} headerTitle={headerTitle} launchForm={launchProceduresForm} />;
+};
+
+export default ProceduresOverview;

--- a/packages/esm-patient-procedures-app/src/procedures/procedures-overview.scss
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures-overview.scss
@@ -1,0 +1,46 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '~@openmrs/esm-styleguide/src/vars' as *;
+
+.widgetCard {
+  border: 1px solid $ui-03;
+}
+
+.content {
+  @include type.type-style('heading-compact-02');
+  color: $text-02;
+  margin-bottom: layout.$spacing-03;
+}
+
+.tileContainer {
+  background-color: $ui-02;
+  border-top: 1px solid $ui-03;
+  padding: layout.$spacing-11 0;
+}
+
+.tile {
+  margin: auto;
+  width: fit-content;
+}
+
+.tileContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.helper {
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+}
+
+.tableContainer {
+  flex: 1;
+}
+
+.table {
+  td {
+    border-bottom: none !important;
+  }
+}

--- a/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
+++ b/packages/esm-patient-procedures-app/src/procedures/procedures.resource.ts
@@ -1,0 +1,104 @@
+import useSWR, { useSWRConfig } from 'swr';
+import { openmrsFetch, restBaseUrl, useDebounce } from '@openmrs/esm-framework';
+import { useEffect, useState } from 'react';
+import {
+  type ConceptReference,
+  type ProcedureApiResponse,
+  type ProcedureTypeApiResponse,
+  type RawProcedure,
+} from '../types';
+
+export function useProcedureTypes() {
+  const url = `${restBaseUrl}/proceduretype?v=full`;
+  const { data, error, isLoading } = useSWR<{ data: ProcedureTypeApiResponse }, Error>(url, openmrsFetch);
+  return { procedureTypes: data?.data?.results ?? [], isLoading };
+}
+
+export function useConceptSearch(query: string, conceptClassUuid: string) {
+  const classParam = conceptClassUuid ? `&class=${conceptClassUuid}` : '';
+  const url = `${restBaseUrl}/concept?name=${query}&searchType=fuzzy${classParam}&v=custom:(uuid,display)`;
+  const { data, error, isLoading } = useSWR<{ data: { results: ConceptReference[] } }, Error>(
+    query ? url : null,
+    openmrsFetch,
+  );
+  return { searchResults: data?.data?.results ?? [], isSearching: isLoading };
+}
+
+export async function saveProcedure(payload: RawProcedure) {
+  return openmrsFetch(`${restBaseUrl}/procedure`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  });
+}
+
+export async function updateProcedure(procedureUuid: string, payload: RawProcedure) {
+  return openmrsFetch(`${restBaseUrl}/procedure/${procedureUuid}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  });
+}
+
+export function useMutatePatientProcedures(patientUuid: string) {
+  const { mutate } = useSWRConfig();
+  return () =>
+    mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/procedure?patient=${patientUuid}`));
+}
+
+export function useProcedures(patientUuid: string) {
+  const url = `${restBaseUrl}/procedure?patient=${patientUuid}&v=full&limit=100`;
+  const { data, error, isLoading, isValidating } = useSWR<{ data: ProcedureApiResponse }, Error>(
+    patientUuid ? url : null,
+    openmrsFetch,
+  );
+  return { procedures: data ? (data.data?.results ?? []) : null, error, isLoading, isValidating };
+}
+
+export async function deleteProcedure(procedureId: string) {
+  const controller = new AbortController();
+  const url = `${restBaseUrl}/procedure/${procedureId}`;
+
+  return await openmrsFetch(url, {
+    method: 'DELETE',
+    signal: controller.signal,
+  });
+}
+
+export function useConceptById(uuid: string) {
+  const url = uuid ? `${restBaseUrl}/concept/${uuid}?v=custom:(uuid,display)` : null;
+  const { data } = useSWR<{ data: ConceptReference }, Error>(url, openmrsFetch);
+  return data?.data ?? null;
+}
+
+export function useConceptSearchField(conceptClassUuid: string, initialValue: string) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedConcept, setSelectedConcept] = useState<ConceptReference | null>(null);
+
+  const debouncedSearchTerm = useDebounce(searchTerm);
+
+  const { searchResults, isSearching } = useConceptSearch(debouncedSearchTerm, conceptClassUuid);
+
+  const initialConceptData = useConceptById(initialValue);
+
+  useEffect(() => {
+    if (initialConceptData) {
+      setSelectedConcept(initialConceptData);
+    }
+  }, [initialConceptData]);
+
+  const clear = () => {
+    setSearchTerm('');
+    setSelectedConcept(null);
+  };
+
+  return {
+    searchTerm,
+    setSearchTerm,
+    selectedConcept,
+    setSelectedConcept,
+    searchResults,
+    isSearching,
+    clear,
+  };
+}

--- a/packages/esm-patient-procedures-app/src/root.component.tsx
+++ b/packages/esm-patient-procedures-app/src/root.component.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import PatientProceduresApp from './patient-procedures-app.component';
+
+const Root: React.FC = () => (
+  <BrowserRouter basename={window.getOpenmrsSpaBase()}>
+    <Routes>
+      <Route path="patient-procedures-app" element={<PatientProceduresApp />} />
+    </Routes>
+  </BrowserRouter>
+);
+
+export default Root;

--- a/packages/esm-patient-procedures-app/src/root.scss
+++ b/packages/esm-patient-procedures-app/src/root.scss
@@ -1,0 +1,5 @@
+@use '@carbon/layout';
+
+.container {
+  padding: layout.$spacing-05;
+}

--- a/packages/esm-patient-procedures-app/src/routes.json
+++ b/packages/esm-patient-procedures-app/src/routes.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json.openmrs.org/routes.schema.json",
+  "workspaces2": [
+    {
+      "name": "procedures-form-workspace",
+      "component": "proceduresFormWorkspace",
+      "window": "procedures-form-window"
+    }
+  ],
+  "workspaceWindows2": [
+    {
+      "name": "procedures-form-window",
+      "group": "patient-chart"
+    }
+  ],
+  "extensions": [
+    {
+      "name": "procedures-overview-widget",
+      "slot": "patient-chart-summary-dashboard-slot",
+      "component": "proceduresOverview",
+      "order": 4,
+      "meta": { "fullWidth": false }
+    },
+    {
+      "name": "procedures-details-widget",
+      "slot": "patient-chart-procedures-dashboard-slot",
+      "component": "proceduresDetailedSummary",
+      "meta": { "fullWidth": false }
+    },
+    {
+      "name": "procedures-summary-dashboard",
+      "component": "proceduresDashboardLink",
+      "slot": "patient-chart-dashboard-slot",
+      "order": 8,
+      "meta": {
+        "slot": "patient-chart-procedures-dashboard-slot",
+        "path": "Procedures"
+      }
+    },
+    {
+      "name": "procedure-delete-confirmation-dialog",
+      "component": "procedureDeleteConfirmationDialog"
+    }
+  ]
+}

--- a/packages/esm-patient-procedures-app/src/types.ts
+++ b/packages/esm-patient-procedures-app/src/types.ts
@@ -1,0 +1,57 @@
+export type ConceptReference = {
+  uuid: string;
+  display: string;
+};
+
+export type PatientReference = {
+  uuid: string;
+  display: string;
+};
+
+export type ProcedureType = {
+  uuid: string;
+  name: string;
+};
+
+export interface RawProcedure {
+  patient: string;
+  procedureCoded?: string;
+  procedureType?: string;
+  bodySite?: string;
+  startDateTime?: string;
+  endDateTime?: string;
+  status?: string;
+  notes?: string;
+  duration?: number;
+  durationUnit?: string;
+}
+
+export type Procedure = {
+  uuid: string;
+  display: string;
+  patient: PatientReference;
+  procedureType: ProcedureType;
+  procedureCoded: ConceptReference;
+  procedureNonCoded: string;
+  bodySite: ConceptReference;
+  startDateTime: string;
+  estimatedStartDate: string;
+  endDateTime: string;
+  duration: number;
+  durationUnit: ConceptReference;
+  status: ConceptReference;
+  outcomeCoded: ConceptReference;
+  outcomeNonCoded: ConceptReference;
+  notes: string;
+  formNamespaceAndPath: string;
+  voided: boolean;
+};
+
+export interface ProcedureApiResponse {
+  results: Array<Procedure>;
+  links: Array<{ rel: string; uri: string }>;
+}
+
+export interface ProcedureTypeApiResponse {
+  results: Array<ProcedureType>;
+}

--- a/packages/esm-patient-procedures-app/translations/en.json
+++ b/packages/esm-patient-procedures-app/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "welcomeToModule": "Welcome to procedures-app!",
+  "getStarted": "Get started by adding routes, extensions, or components."
+}

--- a/packages/esm-patient-procedures-app/tsconfig.json
+++ b/packages/esm-patient-procedures-app/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*", "../../tools/setup-tests.ts"],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,6 +5700,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@openmrs/esm-patient-procedures-app@workspace:packages/esm-patient-procedures-app":
+  version: 0.0.0-use.local
+  resolution: "@openmrs/esm-patient-procedures-app@workspace:packages/esm-patient-procedures-app"
+  dependencies:
+    "@carbon/react": "npm:^1.83.0"
+    "@hookform/resolvers": "npm:^3.3.1"
+    "@openmrs/esm-patient-common-lib": "workspace:*"
+    openmrs: "npm:next"
+    react-hook-form: "npm:^7.46.2"
+    zod: "npm:^3.23.8"
+  peerDependencies:
+    "@openmrs/esm-framework": 9.x
+    "@openmrs/esm-patient-common-lib": 12.x
+    dayjs: 1.x
+    react: 18.x
+    react-i18next: 16.x
+    react-router-dom: 6.x
+    rxjs: 6.x
+    swr: 2.x
+  languageName: unknown
+  linkType: soft
+
 "@openmrs/esm-patient-programs-app@workspace:packages/esm-patient-programs-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-patient-programs-app@workspace:packages/esm-patient-programs-app"


### PR DESCRIPTION
## Summary

Closes Paperclip ticket [JAY-267](/JAY/issues/JAY-267).

Moves `@openmrs/esm-procedures-app` from the standalone [jayasanka-sack/openmrs-esm-procedures-app](https://github.com/jayasanka-sack/openmrs-esm-procedures-app) repository into this monorepo as `packages/esm-patient-procedures-app`, following the same patterns as other packages here.

### Adaptations made to fit the monorepo

- **`package.json`**: version aligned to `12.1.0`; scripts match other packages (`lint`, `extract-translations` uses `../../tools/i18next-parser.config.js`); removed standalone devDependencies hoisted to the root.
- **`tsconfig.json`**: extends root `../../tsconfig.json`.
- **`jest.config.js`**: delegates to root `../../jest.config.js`.
- **`rspack.config.js`**: uses `openmrs/default-rspack-config`.
- **`src/index.ts`**: imports `createDashboardLink` from `@openmrs/esm-patient-common-lib` instead of local stub.
- **`src/dashboard.meta.ts`**: imports `DashboardLinkConfig` from `@openmrs/esm-patient-common-lib`.
- **`src/procedures/procedures-overview.component.tsx`** and **`procedures-detailed-summary.component.tsx`**: import `PatientChartPagination` from `@openmrs/esm-patient-common-lib` instead of local copy.
- Removed `src/common-lib-components/` directory entirely (all replaced by `@openmrs/esm-patient-common-lib`).
- Removed local `DashboardLinkConfig` type from `types.ts` (now comes from common-lib).

## What was tested

- Build and test can't be run in this workspace (no `node_modules` for the patient-chart repo). CI should verify builds and unit tests.
- Verified all imports resolve to correct packages by cross-referencing `esm-patient-common-lib` exports.
- Verified `routes.json` extension components (`proceduresOverview`, `proceduresDetailedSummary`, `proceduresDashboardLink`, `proceduresFormWorkspace`, `procedureDeleteConfirmationDialog`) all match exports in `src/index.ts`.

## Attention points

- The `src/procedures-app.component.tsx`, `src/patient-procedures-app.component.tsx`, and `src/root.component.tsx` appear to be scaffolding stubs from the original repo setup and are not referenced by `routes.json` or `index.ts`. They can be cleaned up if desired.
- `@hookform/resolvers` and `zod` are listed as dependencies in the package — these are already present in the monorepo root `package.json`, so Yarn workspaces will deduplicate them.