### PR TITLE
[Paperclip] refactor(procedures): convert all function declarations to arrow functions

### DIFF
--- a/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.component.test.tsx
@@ -9,7 +9,7 @@ interface HarnessProps {
   idPrefix?: string;
 }
 
-function Harness({ defaultValue = null, idPrefix = 'start' }: HarnessProps) {
+const Harness = ({ defaultValue = null, idPrefix = 'start' }: HarnessProps) => {
   const [value, setValue] = useState<Date | null>(defaultValue);
   return (
     <div>
@@ -19,13 +19,13 @@ function Harness({ defaultValue = null, idPrefix = 'start' }: HarnessProps) {
       <output data-testid="minutes">{value ? String(value.getMinutes()) : ''}</output>
     </div>
   );
-}
+};
 
-async function pickDate(user: ReturnType<typeof userEvent.setup>, date = '2026-04-27') {
+const pickDate = async (user: ReturnType<typeof userEvent.setup>, date = '2026-04-27') => {
   const dateInput = screen.getByLabelText(/^date$/i);
   await user.click(dateInput);
   await user.paste(date);
-}
+};
 
 describe('DateTimeField', () => {
   it('renders date, time, and AM/PM controls', () => {

--- a/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/date-time-field/date-time-field.component.tsx
@@ -6,22 +6,22 @@ import styles from './date-time-field.scss';
 
 const TIME_PATTERN = /^(1[0-2]|0?[1-9]):([0-5]\d)$/;
 
-function formatTime(date: Date | null | undefined): string {
+const formatTime = (date: Date | null | undefined): string => {
   if (!date) return '';
   const hours24 = date.getHours();
   const hours12 = hours24 % 12 === 0 ? 12 : hours24 % 12;
   return `${String(hours12).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-}
+};
 
-function getMeridiem(date: Date | null | undefined): 'AM' | 'PM' {
+const getMeridiem = (date: Date | null | undefined): 'AM' | 'PM' => {
   if (!date) return 'AM';
   return date.getHours() >= 12 ? 'PM' : 'AM';
-}
+};
 
-function to24Hour(hours12: number, meridiem: 'AM' | 'PM'): number {
+const to24Hour = (hours12: number, meridiem: 'AM' | 'PM'): number => {
   if (meridiem === 'AM') return hours12 === 12 ? 0 : hours12;
   return hours12 === 12 ? 12 : hours12 + 12;
-}
+};
 
 interface DateTimeFieldProps {
   idPrefix: string;
@@ -31,7 +31,7 @@ interface DateTimeFieldProps {
   invalidText?: string;
 }
 
-export function DateTimeField({ idPrefix, value, onChange, invalid, invalidText }: DateTimeFieldProps) {
+export const DateTimeField = ({ idPrefix, value, onChange, invalid, invalidText }: DateTimeFieldProps) => {
   const { t } = useTranslation();
   const dateValue = value ?? null;
   const meridiem = getMeridiem(dateValue);
@@ -105,4 +105,4 @@ export function DateTimeField({ idPrefix, value, onChange, invalid, invalidText 
       </TimePicker>
     </div>
   );
-}
+};

--- a/packages/esm-patient-procedures-app/src/components/detailed-summary/procedures-detailed-summary.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/detailed-summary/procedures-detailed-summary.component.tsx
@@ -52,7 +52,7 @@ type ProcedureTableRow = {
   notes?: string;
 };
 
-function ProceduresDetailedSummary({ patient }: ProceduresDetailedSummaryProps) {
+const ProceduresDetailedSummary = ({ patient }: ProceduresDetailedSummaryProps) => {
   const { t } = useTranslation();
   const { procedurePageSize } = useConfig<ConfigObject>();
   const headerTitle = t('procedures', 'Procedures');
@@ -213,6 +213,6 @@ function ProceduresDetailedSummary({ patient }: ProceduresDetailedSummaryProps) 
   }
 
   return <EmptyCard displayText={displayText} headerTitle={headerTitle} launchForm={launchProceduresForm} />;
-}
+};
 
 export default ProceduresDetailedSummary;

--- a/packages/esm-patient-procedures-app/src/index.ts
+++ b/packages/esm-patient-procedures-app/src/index.ts
@@ -14,9 +14,9 @@ const options = {
 
 export const importTranslation = require.context('../translations', false, /.json$/, 'lazy');
 
-export function startupApp() {
+export const startupApp = () => {
   defineConfigSchema(moduleName, configSchema);
-}
+};
 
 // Extensions
 export const proceduresOverview = getSyncLifecycle(ProceduresOverview, options);

--- a/packages/esm-patient-procedures-app/src/procedures.resource.ts
+++ b/packages/esm-patient-procedures-app/src/procedures.resource.ts
@@ -17,7 +17,7 @@ const sourceTypeToRestParam: Record<Exclude<ConceptSourceType, 'any'>, string> =
   'Answer to': 'answerTo',
 };
 
-function buildConceptSearchUrl(query: string, source: ConceptSource): string {
+const buildConceptSearchUrl = (query: string, source: ConceptSource): string => {
   const params = new URLSearchParams({ v: 'custom:(uuid,display)' });
   if (query) {
     params.set('name', query);
@@ -27,15 +27,15 @@ function buildConceptSearchUrl(query: string, source: ConceptSource): string {
     params.set(sourceTypeToRestParam[source.sourceType], source.uuid);
   }
   return `${restBaseUrl}/concept?${params.toString()}`;
-}
+};
 
-export function useProcedureTypes() {
+export const useProcedureTypes = () => {
   const url = `${restBaseUrl}/proceduretype?v=full`;
   const { data, isLoading } = useSWR<{ data: ProcedureTypeApiResponse }, Error>(url, openmrsFetch);
   return { procedureTypes: data?.data?.results ?? [], isLoading };
-}
+};
 
-export function useConceptSearch(query: string, source: ConceptSource) {
+export const useConceptSearch = (query: string, source: ConceptSource) => {
   const hasSourceFilter = Boolean(source.uuid) && source.sourceType !== 'any';
   const url = query || hasSourceFilter ? buildConceptSearchUrl(query, source) : null;
   const { data, isLoading } = useSWR<{ data: { results: ConceptReference[] } }, Error>(url, openmrsFetch);
@@ -46,31 +46,31 @@ export function useConceptSearch(query: string, source: ConceptSource) {
   const uniqueSearchResults = Array.from(new Map(results.map((concept) => [concept.uuid, concept])).values());
 
   return { searchResults: uniqueSearchResults, isSearching: isLoading };
-}
+};
 
-export async function saveProcedure(payload: RawProcedure) {
+export const saveProcedure = async (payload: RawProcedure) => {
   return openmrsFetch(`${restBaseUrl}/procedure`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: payload,
   });
-}
+};
 
-export async function updateProcedure(procedureUuid: string, payload: RawProcedure) {
+export const updateProcedure = async (procedureUuid: string, payload: RawProcedure) => {
   return openmrsFetch(`${restBaseUrl}/procedure/${procedureUuid}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: payload,
   });
-}
+};
 
-export function useMutatePatientProcedures(patientUuid: string) {
+export const useMutatePatientProcedures = (patientUuid: string) => {
   const { mutate } = useSWRConfig();
   return () =>
     mutate((key) => typeof key === 'string' && key.startsWith(`${restBaseUrl}/procedure?patient=${patientUuid}`));
-}
+};
 
-export function useProcedures(patientUuid: string, startIndex = 0, limit = 100) {
+export const useProcedures = (patientUuid: string, startIndex = 0, limit = 100) => {
   const url = `${restBaseUrl}/procedure?patient=${patientUuid}&v=full&startIndex=${startIndex}&limit=${limit}&totalCount=true`;
   const { data, error, isLoading, isValidating } = useSWR<{ data: ProcedureApiResponse }, Error>(
     patientUuid ? url : null,
@@ -83,9 +83,9 @@ export function useProcedures(patientUuid: string, startIndex = 0, limit = 100) 
     isLoading,
     isValidating,
   };
-}
+};
 
-export async function deleteProcedure(procedureId: string) {
+export const deleteProcedure = async (procedureId: string) => {
   const controller = new AbortController();
   const url = `${restBaseUrl}/procedure/${procedureId}`;
 
@@ -93,15 +93,15 @@ export async function deleteProcedure(procedureId: string) {
     method: 'DELETE',
     signal: controller.signal,
   });
-}
+};
 
-export function useConceptById(uuid: string) {
+export const useConceptById = (uuid: string) => {
   const url = uuid ? `${restBaseUrl}/concept/${uuid}?v=custom:(uuid,display)` : null;
   const { data } = useSWR<{ data: ConceptReference }, Error>(url, openmrsFetch);
   return data?.data ?? null;
-}
+};
 
-export function useConceptSearchField(source: ConceptSource, initialValue: string) {
+export const useConceptSearchField = (source: ConceptSource, initialValue: string) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedConcept, setSelectedConcept] = useState<ConceptReference | null>(null);
 
@@ -131,4 +131,4 @@ export function useConceptSearchField(source: ConceptSource, initialValue: strin
     isSearching,
     clear,
   };
-}
+};

--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.workspace.test.tsx
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.workspace.test.tsx
@@ -65,11 +65,11 @@ const defaultProps: PatientWorkspace2DefinitionProps<ProceduresFormProps, object
   showActionMenu: true,
 };
 
-function renderProceduresForm() {
+const renderProceduresForm = () => {
   render(<ProceduresFormWorkspace {...defaultProps} />);
-}
+};
 
-async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+const fillRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
   // The shared mockUseConceptSearch returns the same searchedProcedure mock
   // for every concept search field, so each "Appendectomy" menuitem matches the
   // currently-typed-in field — only one results list is visible at a time.
@@ -90,7 +90,7 @@ async function fillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
   const startGroup = screen.getByRole('group', { name: /start date and time/i });
   await user.click(within(startGroup).getByLabelText(/^date$/i));
   await user.paste('2026-04-27');
-}
+};
 
 beforeEach(() => {
   mockUseProcedureTypes.mockReturnValue({ procedureTypes: mockProcedureTypes, isLoading: false });

--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures.form.tsx
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures.form.tsx
@@ -443,7 +443,7 @@ const ProceduresForm: React.FC<ProceduresFormComponentProps> = ({
   );
 };
 
-function RequiredFieldLabel({ label }: { label: string }) {
+const RequiredFieldLabel = ({ label }: { label: string }) => {
   const { t } = useTranslation();
   return (
     <span>
@@ -453,6 +453,6 @@ function RequiredFieldLabel({ label }: { label: string }) {
       </span>
     </span>
   );
-}
+};
 
 export default ProceduresForm;


### PR DESCRIPTION
## Summary

Converts all `function` declarations in the `esm-patient-procedures-app` package to arrow function expressions, as requested in JAY-313.

**Files changed:**
- `src/components/date-time-field/date-time-field.component.tsx`
- `src/components/date-time-field/date-time-field.component.test.tsx`
- `src/components/detailed-summary/procedures-detailed-summary.component.tsx`
- `src/index.ts`
- `src/procedures.resource.ts`
- `src/workspaces/procedures-form/procedures.form.tsx`
- `src/workspaces/procedures-form/procedures-form.workspace.test.tsx`

## Testing

- All 49 tests in the procedures app pass (`NODE_ENV=test npx vitest run --passWithNoTests`)
- The pre-push hook runs `yarn verify` across all packages in the monorepo. Per Jaye's instruction ("no need to worry about tests from other apps"), `--no-verify` was used to push. Other packages have pre-existing test issues unrelated to this change.

## Notes

- Pure refactor — no behaviour changes, only syntax transformation from `function foo() {}` to `const foo = () => {}`
- Test helper functions inside test files were also converted for consistency