### PR TITLE
[Paperclip] fix(a11y): fix accessibility issues in ConceptSearchField

### DIFF
--- a/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.tsx
@@ -71,9 +71,22 @@ const ConceptSearchResults = ({
 
   if (searchResults?.length > 0) {
     return (
-      <ul className={styles.resultsList}>
+      <ul className={styles.resultsList} role="listbox">
         {searchResults.map((result) => (
-          <li className={styles.resultItem} key={result.uuid} onClick={() => onSelect(result)} role="menuitem">
+          <li
+            aria-selected={false}
+            className={styles.resultItem}
+            key={result.uuid}
+            onClick={() => onSelect(result)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelect(result);
+              }
+            }}
+            role="option"
+            tabIndex={0}
+          >
             {result.display}
           </li>
         ))}

--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.workspace.test.tsx
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.workspace.test.tsx
@@ -71,13 +71,13 @@ const renderProceduresForm = () => {
 
 const fillRequiredFields = async (user: ReturnType<typeof userEvent.setup>) => {
   // The shared mockUseConceptSearch returns the same searchedProcedure mock
-  // for every concept search field, so each "Appendectomy" menuitem matches the
+  // for every concept search field, so each "Appendectomy" option matches the
   // currently-typed-in field — only one results list is visible at a time.
   await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
-  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+  await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
   await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
-  await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+  await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
   const statusGroup = screen.getByRole('group', { name: /^status/i });
   await user.click(within(statusGroup).getByRole('combobox'));
@@ -166,7 +166,7 @@ describe('ProceduresForm', () => {
 
     await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
 
-    expect(screen.getByRole('menuitem', { name: /appendectomy/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /appendectomy/i })).toBeInTheDocument();
   });
 
   it('shows a "No results" tile when a search yields no matches', async () => {
@@ -342,7 +342,7 @@ describe('ProceduresForm', () => {
     renderProceduresForm();
 
     await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
 
     const durationInput = screen.getByRole('spinbutton', { name: /^duration$/i });
     await user.type(durationInput, '5');
@@ -394,9 +394,9 @@ describe('ProceduresForm', () => {
     renderProceduresForm();
 
     await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
     await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
     const statusGroup = screen.getByRole('group', { name: /^status/i });
     await user.click(within(statusGroup).getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: /appendectomy/i }));
@@ -489,9 +489,9 @@ describe('ProceduresForm', () => {
     renderProceduresForm();
 
     await user.type(screen.getByRole('searchbox', { name: /enter procedure/i }), 'App');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
     await user.type(screen.getByRole('searchbox', { name: /enter body site/i }), 'Site');
-    await user.click(screen.getByRole('menuitem', { name: /appendectomy/i }));
+    await user.click(screen.getByRole('option', { name: /appendectomy/i }));
     const statusGroup = screen.getByRole('group', { name: /^status/i });
     await user.click(within(statusGroup).getByRole('combobox'));
     await user.click(screen.getByRole('option', { name: /appendectomy/i }));

--- a/packages/esm-patient-procedures-app/vitest.config.ts
+++ b/packages/esm-patient-procedures-app/vitest.config.ts
@@ -1,4 +1,6 @@
 import { mergeConfig } from 'vitest/config';
 import sharedConfig from '../../tools/vitest.shared';
 
+process.env.NODE_ENV = 'test';
+
 export default mergeConfig(sharedConfig, {});


### PR DESCRIPTION
Resolves [JAY-315](/JAY/issues/JAY-315)

## Summary

- Changed `role="menuitem"` → `role="option"` on search result `<li>` items in `ConceptSearchField`
- Added `role="listbox"` to the parent `<ul>` to establish a valid ARIA listbox/option relationship
- Added `onKeyDown` handler (Enter/Space) so keyboard-only users can select a result
- Added `tabIndex={0}` and `aria-selected={false}` on each option to complete the listbox pattern

Fixes the issues raised in PR #3320 review:
- Parent `<ul>` lacked `role="menu"` (now uses listbox/option pattern instead of menu/menuitem)
- Search result items had `onClick` but no keyboard handler

## Tests

- Updated role assertions in `procedures-form.workspace.test.tsx` to match `role="option"`
- Fixed vitest config (`process.env.NODE_ENV='test'`) to resolve React act() warnings in tests
- All 49 tests in `esm-patient-procedures-app` pass: `5 test files, 49 tests`

## What to review

- The ARIA pattern change from `menu/menuitem` → `listbox/option` is intentional: the component is a search result picker, not a menu. Listbox is the correct semantic for this.
- Keyboard handler only fires on Enter and Space (standard activation keys for interactive list items).