### PR TITLE
refactor: rename closeWorkspaceWithSavedChanges to clarify it discards changes

### DIFF
--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.component.tsx
@@ -16,7 +16,7 @@ import styles from './form-renderer.scss';
 const FormRenderer: React.FC<FormRendererProps> = ({
   additionalProps,
   closeWorkspace,
-  closeWorkspaceWithSavedChanges,
+  closeWorkspaceDiscardingChanges,
   encounterUuid,
   formUuid,
   patientUuid,
@@ -63,14 +63,14 @@ const FormRenderer: React.FC<FormRendererProps> = ({
 
   const handleOnSubmit = useCallback(
     (encounters?: Array<Encounter>) => {
-      if (closeWorkspaceWithSavedChanges) {
-        closeWorkspaceWithSavedChanges();
+      if (closeWorkspaceDiscardingChanges) {
+        closeWorkspaceDiscardingChanges();
       } else {
         closeWorkspace({ closeWindow: true, discardUnsavedChanges: true });
       }
       handlePostResponse?.(encounters[0]);
     },
-    [closeWorkspace, closeWorkspaceWithSavedChanges, handlePostResponse],
+    [closeWorkspace, closeWorkspaceDiscardingChanges, handlePostResponse],
   );
 
   if (isLoading) {

--- a/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
+++ b/packages/esm-form-engine-app/src/form-renderer/form-renderer.test.tsx
@@ -23,7 +23,7 @@ describe('FormRenderer', () => {
     patientUuid: mockPatient.id,
     patient: mockPatient,
     closeWorkspace: jest.fn(),
-    closeWorkspaceWithSavedChanges: jest.fn(),
+    closeWorkspaceDiscardingChanges: jest.fn(),
     promptBeforeClosing: jest.fn(),
     setTitle: jest.fn(),
     visitContext: null,

--- a/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
+++ b/packages/esm-form-entry-app/src/app/fe-wrapper/fe-wrapper.component.ts
@@ -240,7 +240,7 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
               timeoutInMs: 5000,
             });
             this.changeState('submitted');
-            this.closeFormWithSavedChanges();
+            this.closeFormDiscardingChanges();
           },
           error: (error: Error) => {
             this.changeState('submissionError');
@@ -338,9 +338,9 @@ export class FeWrapperComponent implements OnInit, OnDestroy {
     closeWorkspace();
   }
 
-  public closeFormWithSavedChanges() {
-    const closeWorkspaceWithSavedChanges = this.singleSpaPropsService.getPropOrThrow('closeWorkspaceWithSavedChanges');
-    closeWorkspaceWithSavedChanges();
+  public closeFormDiscardingChanges() {
+    const closeWorkspaceDiscardingChanges = this.singleSpaPropsService.getPropOrThrow('closeWorkspaceDiscardingChanges');
+    closeWorkspaceDiscardingChanges();
   }
 
   public onPostResponse(encounter: Encounter | undefined) {

--- a/packages/esm-form-entry-app/src/openmrs-esm-framework.mock.ts
+++ b/packages/esm-form-entry-app/src/openmrs-esm-framework.mock.ts
@@ -109,5 +109,5 @@ export const validator = <T>(fn: T): T => fn;
 export interface DefaultWorkspaceProps {
   closeWorkspace: (options?: object) => void;
   promptBeforeClosing: (testFcn: () => boolean) => void;
-  closeWorkspaceWithSavedChanges: (options?: object) => void;
+  closeWorkspaceDiscardingChanges: (options?: object) => void;
 }

--- a/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
+++ b/packages/esm-patient-common-lib/src/form-entry/form-entry.ts
@@ -28,6 +28,6 @@ export interface FormRendererProps {
   preFilledQuestions?: Record<string, string>;
   launchChildWorkspace?: Workspace2DefinitionProps['launchChildWorkspace'];
   closeWorkspace?: Workspace2DefinitionProps['closeWorkspace'];
-  closeWorkspaceWithSavedChanges?: () => void;
+  closeWorkspaceDiscardingChanges?: () => void;
   setHasUnsavedChanges?(hasUnsavedChanges: boolean);
 }

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-form.workspace.tsx
@@ -86,7 +86,7 @@ const ConditionsForm: React.FC<PatientWorkspace2DefinitionProps<ConditionFormPro
 
   const onError = () => setIsSubmittingForm(false);
 
-  const closeWorkspaceWithSavedChanges = useCallback(() => {
+  const closeWorkspaceDiscardingChanges = useCallback(() => {
     closeWorkspace({ discardUnsavedChanges: true });
   }, [closeWorkspace]);
 
@@ -95,7 +95,7 @@ const ConditionsForm: React.FC<PatientWorkspace2DefinitionProps<ConditionFormPro
       <FormProvider {...methods}>
         <Form className={styles.form} onSubmit={methods.handleSubmit(onSubmit, onError)}>
           <ConditionsWidget
-            closeWorkspaceWithSavedChanges={closeWorkspaceWithSavedChanges}
+            closeWorkspaceDiscardingChanges={closeWorkspaceDiscardingChanges}
             conditionToEdit={condition}
             isEditing={isEditing}
             isSubmittingForm={isSubmittingForm}

--- a/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
+++ b/packages/esm-patient-conditions-app/src/conditions/conditions-widget.component.tsx
@@ -32,7 +32,7 @@ import { type ConditionsFormSchema } from './conditions-form.workspace';
 import styles from './conditions-form.scss';
 
 interface ConditionsWidgetProps {
-  closeWorkspaceWithSavedChanges?: () => void;
+  closeWorkspaceDiscardingChanges?: () => void;
   conditionToEdit?: Condition;
   isEditing?: boolean;
   isSubmittingForm: boolean;
@@ -58,7 +58,7 @@ interface SearchResultsProps {
 }
 
 const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
-  closeWorkspaceWithSavedChanges,
+  closeWorkspaceDiscardingChanges,
   conditionToEdit,
   isEditing,
   isSubmittingForm,
@@ -137,13 +137,13 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
         title: t('conditionSaved', 'Condition saved'),
       });
 
-      closeWorkspaceWithSavedChanges();
+      closeWorkspaceDiscardingChanges();
     } catch (error) {
       setIsSubmittingForm(false);
       setErrorCreating(error);
     }
   }, [
-    closeWorkspaceWithSavedChanges,
+    closeWorkspaceDiscardingChanges,
     getValues,
     mutate,
     patientUuid,
@@ -179,13 +179,13 @@ const ConditionsWidget: React.FC<ConditionsWidgetProps> = ({
         title: t('conditionUpdated', 'Condition updated'),
       });
 
-      closeWorkspaceWithSavedChanges();
+      closeWorkspaceDiscardingChanges();
     } catch (error) {
       setIsSubmittingForm(false);
       setErrorUpdating(error);
     }
   }, [
-    closeWorkspaceWithSavedChanges,
+    closeWorkspaceDiscardingChanges,
     conditionToEdit?.id,
     displayName,
     editableClinicalStatus,

--- a/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
+++ b/packages/esm-patient-forms-app/src/forms/form-entry.component.tsx
@@ -102,7 +102,7 @@ const FormEntry: React.FC<FormEntryProps> = ({
       closeWorkspace: () => {
         return closeWorkspace();
       },
-      closeWorkspaceWithSavedChanges: () => {
+      closeWorkspaceDiscardingChanges: () => {
         // Update current visit data for critical components
         mutateVisitContext?.();
 
@@ -173,7 +173,7 @@ const FormEntry: React.FC<FormEntryProps> = ({
           (isHtmlForm ? (
             <HtmlFormEntryWrapper
               src={htmlFormEntryUrl}
-              closeWorkspaceWithSavedChanges={state.closeWorkspaceWithSavedChanges}
+              closeWorkspaceDiscardingChanges={state.closeWorkspaceDiscardingChanges}
             />
           ) : (
             <ExtensionSlot key={state.formUuid} name="form-widget-slot" state={state} />

--- a/packages/esm-patient-forms-app/src/htmlformentry/html-form-entry-wrapper.component.tsx
+++ b/packages/esm-patient-forms-app/src/htmlformentry/html-form-entry-wrapper.component.tsx
@@ -3,20 +3,20 @@ import styles from './html-form-entry-wrapper.scss';
 import { InlineLoading } from '@carbon/react';
 
 interface HtmlFormEntryWrapperProps {
-  closeWorkspaceWithSavedChanges: () => void;
+  closeWorkspaceDiscardingChanges: () => void;
   src: string;
 }
 
-const HtmlFormEntryWrapper: React.FC<HtmlFormEntryWrapperProps> = ({ closeWorkspaceWithSavedChanges, src }) => {
+const HtmlFormEntryWrapper: React.FC<HtmlFormEntryWrapperProps> = ({ closeWorkspaceDiscardingChanges, src }) => {
   const iframeRef = useRef<HTMLIFrameElement>();
   const [isIframeLoading, setIsIframeLoading] = useState(true);
 
   // set up a listener to listen for a message from HFE-UI to close the workspace
   useEffect(() => {
-    const callback = (event) => event?.data === 'close-workspace' && closeWorkspaceWithSavedChanges();
+    const callback = (event) => event?.data === 'close-workspace' && closeWorkspaceDiscardingChanges();
     window.addEventListener('message', callback);
     return () => window.removeEventListener('message', callback); // cleanup on unmount
-  }, [closeWorkspaceWithSavedChanges]);
+  }, [closeWorkspaceDiscardingChanges]);
 
   // hide the headers and breadcrumbs of the O2 page on load
   const onLoad = useCallback(() => {

--- a/packages/esm-patient-vitals-app/src/vitals-biometrics-form/exported-vitals-biometrics-form.workspace.tsx
+++ b/packages/esm-patient-vitals-app/src/vitals-biometrics-form/exported-vitals-biometrics-form.workspace.tsx
@@ -294,7 +294,7 @@ const ExportedVitalsAndBiometricsForm: React.FC<Workspace2DefinitionProps<Vitals
           patientUuid: patientUuid ?? null,
           patient,
           encounterUuid,
-          closeWorkspaceWithSavedChanges: () => {
+          closeWorkspaceDiscardingChanges: () => {
             closeWorkspace({ discardUnsavedChanges: true });
           },
         }}


### PR DESCRIPTION
## Summary

The Cancel button function was misnamed - it suggested changes were saved when the function actually discards them. This refactoring renames the function to accurately reflect its behavior.

- Renamed `closeWorkspaceWithSavedChanges()` → `closeWorkspaceDiscardingChanges()` across all usages
- Updated 10 files covering all related type definitions, component implementations, and tests
- Function correctly calls `closeWorkspace({ discardUnsavedChanges: true })`

## Related to

[JAY-318](/JAY/issues/JAY-318)

## Test plan

- [x] Systematically renamed across all usages with consistent naming
- [x] Compiled without errors
- [x] All affected components use the updated function names