### PR TITLE
[Paperclip] fix(procedures): re-enable delete button after failed delete

### DIFF
--- a/packages/esm-patient-procedures-app/src/modals/delete-procedure/delete-procedure.modal.test.tsx
+++ b/packages/esm-patient-procedures-app/src/modals/delete-procedure/delete-procedure.modal.test.tsx
@@ -82,7 +82,7 @@ describe('<DeleteProcedureModal />', () => {
       title: 'Error deleting procedure',
       subtitle: 'Internal server error',
     });
-    expect(deleteButton).toBeDisabled();
+    expect(deleteButton).not.toBeDisabled();
 
     consoleSpy.mockRestore();
   });

--- a/packages/esm-patient-procedures-app/src/modals/delete-procedure/delete-procedure.modal.tsx
+++ b/packages/esm-patient-procedures-app/src/modals/delete-procedure/delete-procedure.modal.tsx
@@ -35,6 +35,7 @@ const DeleteProcedureModal: React.FC<DeleteProcedureModalProps> = ({
         title: t('procedureDeleted', 'Procedure deleted'),
       });
     } catch (error) {
+      setIsDeleting(false);
       console.error('Error deleting procedure: ', error);
 
       showSnackbar({


### PR DESCRIPTION
Fixes JAY-319. Added setIsDeleting(false) in the catch block so the Delete button is re-enabled after a failed delete. Updated the test assertion to verify not.toBeDisabled() after an error. All 49 procedures tests pass.