### PR TITLE
[Paperclip] style(procedures): remove duplicated SCSS from procedures-form

### DIFF
--- a/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.scss
+++ b/packages/esm-patient-procedures-app/src/workspaces/procedures-form/procedures-form.scss
@@ -3,41 +3,6 @@
 @use '@carbon/type';
 @use '@openmrs/esm-styleguide/src/vars' as *;
 
-.resultItem {
-  padding: layout.$spacing-04;
-  border-top: 0.0625rem solid $grey-2;
-
-  &:first-of-type {
-    border-top: none;
-  }
-
-  &:last-of-type {
-    border-bottom: none;
-  }
-}
-
-.resultsList {
-  background-color: $ui-02;
-  max-height: 14rem;
-  overflow-y: auto;
-  border: 1px solid $ui-03;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-
-  li:hover {
-    background-color: $ui-03;
-    cursor: pointer;
-  }
-}
-
-.emptyResults {
-  @include type.type-style('body-compact-01');
-  color: $text-02;
-  min-height: layout.$spacing-05;
-  border: 1px solid $ui-03;
-}
-
 .form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Removes `.resultItem`, `.resultsList`, and `.emptyResults` SCSS rules from `procedures-form.scss` — they are identical copies of the styles in `concept-search-field.scss`.

**Confirmed unused in the form:** a grep across all `.tsx`/`.ts` files in the procedures app shows these class names are only referenced in `concept-search-field.component.tsx`, not in any procedures-form file. They were leftovers from before `ConceptSearchField` was extracted into its own component.

- Deleted 35 lines (the three duplicate rule blocks)
- `concept-search-field.scss` continues to own these styles
- No functional change — the rendered output is identical

## Testing

- Style-only change with no runtime behavior; no unit tests required.
- Could not run the dev server in this environment — visual regression should be verified by reviewing the procedures form in a running instance.

## Ticket

Paperclip: [JAY-317](/JAY/issues/JAY-317)