### PR TITLE
(test) JAY-330: Add unit tests for ConceptSearchField and ProceduresActionMenu

### DIFF
--- a/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, within } from '@testing-library/react';
+import { launchWorkspace2, showModal, useLayoutType } from '@openmrs/esm-framework';
+import { mockProceduresResponse } from '__mocks__';
+import { ProceduresActionMenu } from './procedures-action-menu.component';
+
+const mockLaunchWorkspace2 = vi.mocked(launchWorkspace2);
+const mockShowModal = vi.mocked(showModal);
+const mockUseLayoutType = vi.mocked(useLayoutType);
+
+vi.mock('@openmrs/esm-framework', async () => ({
+  ...(await vi.importActual('@openmrs/esm-framework')),
+  launchWorkspace2: vi.fn(),
+  showModal: vi.fn().mockReturnValue(vi.fn()),
+  useLayoutType: vi.fn().mockReturnValue('small-desktop'),
+}));
+
+const mockProcedure = mockProceduresResponse.results[0];
+const patientUuid = '8673ee4f-e2ab-4077-ba55-4980f408773e';
+
+const defaultProps = {
+  procedure: mockProcedure,
+  patientUuid,
+};
+
+function getMenuTrigger() {
+  return screen.getByRole('button', { name: /options/i });
+}
+
+async function openMenu(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = getMenuTrigger();
+  await user.click(trigger);
+  const panelId = trigger.getAttribute('aria-controls');
+  return document.getElementById(panelId!);
+}
+
+describe('<ProceduresActionMenu />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLayoutType.mockReturnValue('small-desktop');
+    mockShowModal.mockReturnValue(vi.fn());
+  });
+
+  it('renders the overflow menu', () => {
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    expect(getMenuTrigger()).toBeInTheDocument();
+  });
+
+  it('renders Edit and Delete menu items after opening the menu', async () => {
+    const user = userEvent.setup();
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    const panel = await openMenu(user);
+
+    expect(within(panel!).getByText('Edit')).toBeInTheDocument();
+    expect(within(panel!).getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('clicking Edit launches the procedures form workspace', async () => {
+    const user = userEvent.setup();
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    const panel = await openMenu(user);
+    await user.click(within(panel!).getByText('Edit'));
+
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('procedures-form-workspace', {
+      procedure: mockProcedure,
+      formContext: 'editing',
+    });
+  });
+
+  it('clicking Delete opens the confirmation modal', async () => {
+    const user = userEvent.setup();
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    const panel = await openMenu(user);
+    await user.click(within(panel!).getByText('Delete'));
+
+    expect(mockShowModal).toHaveBeenCalledWith(
+      'procedure-delete-confirmation-dialog',
+      expect.objectContaining({
+        procedureUuid: mockProcedure.uuid,
+        patientUuid,
+      }),
+    );
+  });
+
+  it('uses lg size on tablet layout', () => {
+    mockUseLayoutType.mockReturnValue('tablet');
+
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    expect(getMenuTrigger()).toHaveClass('cds--overflow-menu--lg');
+  });
+
+  it('uses sm size on desktop layout', () => {
+    mockUseLayoutType.mockReturnValue('small-desktop');
+
+    render(<ProceduresActionMenu {...defaultProps} />);
+
+    expect(getMenuTrigger()).toHaveClass('cds--overflow-menu--sm');
+  });
+});

--- a/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen, within } from '@testing-library/react';
 import { launchWorkspace2, showModal, useLayoutType } from '@openmrs/esm-framework';
 import { mockProceduresResponse } from '__mocks__';
+import { type Procedure } from '../../types';
 import { ProceduresActionMenu } from './procedures-action-menu.component';
 
 const mockLaunchWorkspace2 = vi.mocked(launchWorkspace2);
@@ -17,7 +18,7 @@ vi.mock('@openmrs/esm-framework', async () => ({
   useLayoutType: vi.fn().mockReturnValue('small-desktop'),
 }));
 
-const mockProcedure = mockProceduresResponse.results[0];
+const mockProcedure = mockProceduresResponse.results[0] as Procedure;
 const patientUuid = '8673ee4f-e2ab-4077-ba55-4980f408773e';
 
 const defaultProps = {

--- a/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.test.tsx
@@ -36,7 +36,7 @@ async function openMenu(user: ReturnType<typeof userEvent.setup>) {
   return document.getElementById(panelId!);
 }
 
-describe('<ProceduresActionMenu />', () => {
+describe('Procedures Action Menu', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseLayoutType.mockReturnValue('small-desktop');

--- a/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import { ConceptSearchField } from './concept-search-field.component';
+import { type ConceptReference } from '../../types';
+
+const createMockField = (overrides = {}) => ({
+  searchTerm: '',
+  setSearchTerm: vi.fn(),
+  selectedConcept: null as ConceptReference | null,
+  setSelectedConcept: vi.fn(),
+  searchResults: [] as Array<ConceptReference>,
+  isSearching: false,
+  clear: vi.fn(),
+  ...overrides,
+});
+
+const defaultProps = {
+  label: 'Procedure',
+  placeholder: 'Search for a procedure',
+  onChange: vi.fn(),
+};
+
+describe('<ConceptSearchField />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders search input with label and placeholder', () => {
+    const field = createMockField();
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.getByRole('searchbox', { name: /procedure/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search for a procedure')).toBeInTheDocument();
+  });
+
+  it('typing calls setSearchTerm and clears selected concept', async () => {
+    const user = userEvent.setup();
+    const field = createMockField();
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    const searchInput = screen.getByRole('searchbox');
+    await user.type(searchInput, 'App');
+
+    expect(field.setSearchTerm).toHaveBeenCalled();
+    expect(field.setSelectedConcept).toHaveBeenCalledWith(null);
+  });
+
+  it('clearing the search input calls field.clear', async () => {
+    const user = userEvent.setup();
+    const field = createMockField({ searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    const clearButton = screen.getByRole('button', { name: /clear search input/i });
+    await user.click(clearButton);
+
+    expect(field.clear).toHaveBeenCalled();
+  });
+
+  it('displays selected concept display name in the search input', () => {
+    const selectedConcept: ConceptReference = { uuid: '1', display: 'Appendectomy' };
+    const field = createMockField({ selectedConcept, searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.getByDisplayValue('Appendectomy')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner while searching', () => {
+    const field = createMockField({ isSearching: true, searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.getByText(/searching\.\.\./i)).toBeInTheDocument();
+  });
+
+  it('renders search results as a listbox', () => {
+    const searchResults: Array<ConceptReference> = [
+      { uuid: '1', display: 'Appendectomy' },
+      { uuid: '2', display: 'Appendix removal' },
+    ];
+    const field = createMockField({ searchResults, searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(2);
+    expect(screen.getByRole('option', { name: 'Appendectomy' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Appendix removal' })).toBeInTheDocument();
+  });
+
+  it('clicking a result selects it and fires onChange', async () => {
+    const user = userEvent.setup();
+    const result: ConceptReference = { uuid: '1', display: 'Appendectomy' };
+    const field = createMockField({ searchResults: [result], searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    await user.click(screen.getByRole('option', { name: 'Appendectomy' }));
+
+    expect(field.setSelectedConcept).toHaveBeenCalledWith(result);
+    expect(field.setSearchTerm).toHaveBeenCalledWith('');
+    expect(defaultProps.onChange).toHaveBeenCalledWith(result);
+  });
+
+  it('pressing Enter on a result selects it', async () => {
+    const user = userEvent.setup();
+    const result: ConceptReference = { uuid: '1', display: 'Appendectomy' };
+    const field = createMockField({ searchResults: [result], searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    const option = screen.getByRole('option', { name: 'Appendectomy' });
+    option.focus();
+    await user.keyboard('{Enter}');
+
+    expect(field.setSelectedConcept).toHaveBeenCalledWith(result);
+    expect(field.setSearchTerm).toHaveBeenCalledWith('');
+    expect(defaultProps.onChange).toHaveBeenCalledWith(result);
+  });
+
+  it('pressing Space on a result selects it', async () => {
+    const user = userEvent.setup();
+    const result: ConceptReference = { uuid: '1', display: 'Appendectomy' };
+    const field = createMockField({ searchResults: [result], searchTerm: 'App' });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    const option = screen.getByRole('option', { name: 'Appendectomy' });
+    option.focus();
+    await user.keyboard(' ');
+
+    expect(field.setSelectedConcept).toHaveBeenCalledWith(result);
+    expect(field.setSearchTerm).toHaveBeenCalledWith('');
+    expect(defaultProps.onChange).toHaveBeenCalledWith(result);
+  });
+
+  it('shows empty-state tile when no results match', () => {
+    const field = createMockField({ searchTerm: 'xyz', searchResults: [], isSearching: false });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.getByText(/no results for/i)).toBeInTheDocument();
+    expect(screen.getByText(/"xyz"/i)).toBeInTheDocument();
+  });
+
+  it('hides results when there is no search term', () => {
+    const field = createMockField({ searchTerm: '', searchResults: [] });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByText(/no results for/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/searching/i)).not.toBeInTheDocument();
+  });
+
+  it('hides results when a concept is already selected', () => {
+    const selectedConcept: ConceptReference = { uuid: '1', display: 'Appendectomy' };
+    const field = createMockField({
+      selectedConcept,
+      searchTerm: 'App',
+      searchResults: [selectedConcept],
+    });
+
+    render(<ConceptSearchField {...defaultProps} field={field} />);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(screen.queryByText(/searching/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/concept-search-field/concept-search-field.component.test.tsx
@@ -22,7 +22,7 @@ const defaultProps = {
   onChange: vi.fn(),
 };
 
-describe('<ConceptSearchField />', () => {
+describe('Concept Search Field', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Adds unit tests for two components on the feat/procedure-history branch:

- 12 tests for `ConceptSearchField` — covers render, search term callbacks, clear, selected concept display, loading state, results listbox, click/keyboard item selection, empty state, and hidden states (no search term / concept already selected)
- 6 tests for `ProceduresActionMenu` — covers overflow menu render, Edit/Delete items visible after open, Edit workspace launch, Delete modal, and tablet (lg) / desktop (sm) size variants

Both test files use Vitest + @testing-library/react + userEvent, following the patterns in `procedures-overview.component.test.tsx` and `delete-procedure.modal.test.tsx`.

Note: Carbon's `OverflowMenu` renders its panel in a portal referenced via `aria-controls`. The action menu tests use `document.getElementById(trigger.getAttribute('aria-controls')!)` + `within(panel)` to reach portal content — this is the correct query pattern for Carbon menus in jsdom.

## Screenshots

N/A — unit tests only, no UI changes.

## Related Issue

https://github.com/jayasanka-sack/openmrs-esm-patient-chart/issues

## Other

N/A