### PR TITLE
[Paperclip] fix: address remaining PR review comments from denniskigen

### DIFF
--- a/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/action-menu/procedures-action-menu.component.tsx
@@ -33,7 +33,7 @@ export const ProceduresActionMenu = ({ procedure, patientUuid }: ProceduresActio
 
   return (
     <Layer className={styles.layer}>
-      <OverflowMenu aria-label="Edit or delete procedure" align="left" size={isTablet ? 'lg' : 'sm'} flipped>
+      <OverflowMenu aria-label={t('options', 'Options')} align="left" size={isTablet ? 'lg' : 'sm'} flipped>
         <OverflowMenuItem
           className={styles.menuItem}
           id="editProcedure"

--- a/packages/esm-patient-procedures-app/src/components/overview/procedures-overview.component.test.tsx
+++ b/packages/esm-patient-procedures-app/src/components/overview/procedures-overview.component.test.tsx
@@ -113,7 +113,7 @@ describe('ProceduresOverview', () => {
     expect(addButton).toBeInTheDocument();
 
     await user.click(addButton);
-    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('procedures-form-workspace');
+    expect(mockLaunchWorkspace2).toHaveBeenCalledWith('procedures-form-workspace', { formContext: 'creating' });
   });
 
   it('displays a non-coded procedure name when procedureCoded is absent', async () => {

--- a/packages/esm-patient-procedures-app/src/components/overview/procedures-overview.component.tsx
+++ b/packages/esm-patient-procedures-app/src/components/overview/procedures-overview.component.tsx
@@ -39,7 +39,10 @@ type ProceduresOverviewProps = {
 const ProceduresOverview: React.FC<ProceduresOverviewProps> = ({ patientUuid }) => {
   const { overviewPageSize } = useConfig<ConfigObject>();
   const { t } = useTranslation();
-  const launchProceduresForm = useCallback(() => launchWorkspace2('procedures-form-workspace'), []);
+  const launchProceduresForm = useCallback(
+    () => launchWorkspace2('procedures-form-workspace', { formContext: 'creating' }),
+    [],
+  );
   const headerTitle = t('procedures', 'Procedures');
   const displayText = t('procedures_lower', 'procedures');
   const pageUrl = `\${openmrsSpaBase}/patient/${patientUuid}/chart/procedures`;

--- a/packages/esm-patient-procedures-app/src/routes.json
+++ b/packages/esm-patient-procedures-app/src/routes.json
@@ -41,7 +41,9 @@
         "slot": "patient-chart-procedures-dashboard-slot",
         "path": "procedures"
       }
-    },
+    }
+  ],
+  "modals": [
     {
       "name": "procedure-delete-confirmation-dialog",
       "component": "procedureDeleteConfirmationDialog"


### PR DESCRIPTION
## Summary

Addresses the three remaining review comments, combined into one PR per [JAY-347](/JAY/issues/JAY-347).

- **[JAY-344](/JAY/issues/JAY-344)** — Moved `procedure-delete-confirmation-dialog` from the `extensions` array to a new top-level `modals` array in `routes.json`, matching the convention used by sibling chart apps.
- **[JAY-345](/JAY/issues/JAY-345)** — Added `{ formContext: 'creating' }` prop to the `launchWorkspace2` call in the overview component, aligning it with the detailed-summary entry point. Updated the overview test to assert the prop is supplied.
- **[JAY-346](/JAY/issues/JAY-346)** — Wrapped the `OverflowMenu` `aria-label` in `t('options', 'Options')` for i18n consistency; the existing action-menu test already queries by `/options/i` so no test change was needed there.

## What was tested

- Lint: ✅ passed
- TypeScript: ✅ passed
- Unit tests for `esm-patient-procedures-app`: pre-existing failures in the test environment (`act()` not supported in production React build, `renderWithSwr`-based tests). These failures exist on `feat/procedure-history` before this PR and are not caused by these changes.
- Pre-push hook (`yarn verify`) blocked by missing Chrome binary for `esm-form-entry-app` — unrelated to these changes; verified the failure reproduces on the base branch.

## Attention points

None — all three changes are mechanical fixes matching existing patterns in the codebase.