### PR TITLE
[Paperclip] fix(security): resolve shell-quote GHSA-w7jw-789q-3m8p

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "*.{css,scss,ts,tsx}": "prettier --write --list-different"
   },
   "resolutions": {
-    "sass": "^1.54.3"
+    "sass": "^1.54.3",
+    "shell-quote": ">=1.8.4"
   },
   "packageManager": "yarn@4.10.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21570,10 +21570,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 10/af19ab5a1ec30cb4b2f91fd6df49a7442d5c4825a2e269b3712eded10eedd7f9efeaab96d57829880733fc55bcdd8e9b1d8589b4befb06667c731d08145e274d
+"shell-quote@npm:>=1.8.4":
+  version: 1.9.0
+  resolution: "shell-quote@npm:1.9.0"
+  checksum: 10/c3bc91e74a469c4f96b6fd13b0c777fff16bcbda202692a4e5402d3d6b78fc6e02fe92fdf8dc0bddf992a9c6758e43207bfc5bdbefbf8a58190b1c885cbcc171
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves [JAY-465](/JAY/issues/JAY-465).

- Adds `"shell-quote": ">=1.8.4"` to the `resolutions` field in `package.json`, forcing all instances of `shell-quote` to resolve to a patched version.
- Yarn resolved to `1.9.0` (the latest). All three installed copies (root `node_modules`, `esm-form-entry-app`, and `build-angular` sub-install) are now at `1.9.0`.
- Only `package.json` and `yarn.lock` changed — no application code touched.

**Vulnerability:** [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) / CVE-2026-9277 (Critical, CVSS 9.2). `shell-quote`'s `quote()` did not escape newlines in object `.op` values, allowing shell command injection. Fixed in `1.8.4`.

## Testing

- `yarn install` completed cleanly; all `shell-quote` instances now resolve to `1.9.0`.
- `yarn verify` ran 65 tasks: **61 passed**. The only failure is `@openmrs/esm-form-entry-app#test`, which requires a ChromeHeadless binary that is not available in this workspace environment. This failure is pre-existing and unrelated to the `package.json`/`yarn.lock` change; CI on GitHub should run it correctly.

## Notes for Jaye

- The task description referenced `owasp/shell-quote`, but that repo does not exist. The actual upstream is `ljharb/shell-quote`, and the fix was already shipped in version `1.8.4` / `1.9.0`. This PR applies the fix on the consumer side (upgrading the transitive dependency), which is the appropriate action.
- Marked as **draft** because `esm-form-entry-app` tests could not be confirmed locally (no Chrome). Please verify CI passes before merging.